### PR TITLE
Add dynamic version from git

### DIFF
--- a/app/core/version.py
+++ b/app/core/version.py
@@ -1,0 +1,35 @@
+# app/core/version.py
+"""Dynamic version generation from git metadata."""
+import subprocess
+from functools import lru_cache
+
+
+@lru_cache()
+def get_version() -> str:
+    """Generate version string from git: 0.<commit_count>.<short_hash>
+
+    Example: 0.71.840eba4
+    """
+    try:
+        # Get commit count
+        commit_count = subprocess.run(
+            ["git", "rev-list", "--count", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True
+        ).stdout.strip()
+
+        # Get short hash
+        short_hash = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True
+        ).stdout.strip()
+
+        return f"0.{commit_count}.{short_hash}"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "0.0.0-unknown"
+
+
+VERSION = get_version()

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 from fastapi import FastAPI
 from app.core.config import settings
+from app.core.version import VERSION
 from app.api.endpoints import stamps, data, wallet
 import logging
 
@@ -10,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title=settings.PROJECT_NAME,
+    version=VERSION,
     openapi_url=f"{settings.API_V1_STR}/openapi.json" # Standard location for OpenAPI spec
 )
 


### PR DESCRIPTION
## Summary
- Add `app/core/version.py` that generates version from git metadata
- Version format: `0.<commit_count>.<short_hash>` (e.g., `0.71.840eba4`)
- Version auto-updates with each commit/merge
- Falls back to `0.0.0-unknown` if git not available

## Test plan
- [ ] Verify `/docs` shows updated version badge
- [ ] Core tests pass (53/53)