### PR TITLE
Fix version for Docker builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,8 +16,19 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          fetch-depth: 0  # Need full history for commit count
+
+      - name: generate version
+        id: version
+        run: |
+          COMMIT_COUNT=$(git rev-list --count HEAD)
+          SHORT_HASH=$(git rev-parse --short HEAD)
+          VERSION="0.${COMMIT_COUNT}.${SHORT_HASH}"
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated version: ${VERSION}"
+
       - name: build docker image
-        run: docker build -t swarm_connect:$GITHUB_REF_NAME .
+        run: docker build --build-arg VERSION=${{ steps.version.outputs.version }} -t swarm_connect:$GITHUB_REF_NAME .
 
       - name: deploy
         run: >

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ venv/
 .env
 *.sqlite3
 *.db
+VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the rest of the application code
 COPY . .
 
+# Version is passed as build arg and written to VERSION file
+ARG VERSION=0.0.0-unknown
+RUN echo "${VERSION}" > VERSION
+
 # Command to run the application
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/core/version.py
+++ b/app/core/version.py
@@ -1,17 +1,33 @@
 # app/core/version.py
-"""Dynamic version generation from git metadata."""
+"""Dynamic version generation from git metadata or VERSION file."""
 import subprocess
 from functools import lru_cache
+from pathlib import Path
+
+
+VERSION_FILE = Path(__file__).parent.parent.parent / "VERSION"
 
 
 @lru_cache()
 def get_version() -> str:
-    """Generate version string from git: 0.<commit_count>.<short_hash>
+    """Generate version string from git or VERSION file.
 
+    Format: 0.<commit_count>.<short_hash>
     Example: 0.71.840eba4
+
+    Priority:
+    1. VERSION file (for Docker/production)
+    2. Git commands (for local development)
+    3. Fallback to 0.0.0-unknown
     """
+    # Try VERSION file first (used in Docker builds)
+    if VERSION_FILE.exists():
+        version = VERSION_FILE.read_text().strip()
+        if version:
+            return version
+
+    # Try git commands (local development)
     try:
-        # Get commit count
         commit_count = subprocess.run(
             ["git", "rev-list", "--count", "HEAD"],
             capture_output=True,
@@ -19,7 +35,6 @@ def get_version() -> str:
             check=True
         ).stdout.strip()
 
-        # Get short hash
         short_hash = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],
             capture_output=True,


### PR DESCRIPTION
## Summary
Production was showing `0.0.0-unknown` because git commands don't work in Docker containers.

Changes:
- Version module now checks for `VERSION` file first, then falls back to git
- Dockerfile accepts `VERSION` build arg and writes it to file
- GitHub Actions workflow generates version from git and passes it as build arg
- `fetch-depth: 0` added to checkout to get full commit history

## How it works
1. GitHub Actions generates version: `0.<commit_count>.<short_hash>`
2. Passes to Docker build: `--build-arg VERSION=0.75.abc1234`
3. Dockerfile writes to `VERSION` file
4. App reads `VERSION` file at runtime

## Test plan
- [ ] Merge and verify production shows correct version
- [ ] Core tests pass (53/53)