### PR TITLE
Add utilizationPercent field to stamp responses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ python -m pytest tests/test_manifest_upload.py -v
 - `StampDetails` model with optional fields to handle missing data from upstream API
 - Field aliases for API compatibility (`amount` aliased as `value`, etc.)
 - Calculated `expectedExpiration` field in `YYYY-MM-DD-HH-MM` UTC format
+- Calculated `utilizationPercent` field showing stamp usage as percentage (0-100%)
 
 ### Environment Configuration
 

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Swarm Connect is a FastAPI-based API gateway that provides comprehensive access 
 - **List All Stamps**: Retrieve comprehensive list of all available stamps with enhanced data
 - **Get Stamp Details**: Fetch specific stamp information by batch ID
 - **Expiration Calculation**: Automatically calculates stamp expiration time (current time + TTL)
+- **Utilization Percentage**: Calculates human-readable stamp usage percentage (0-100%)
 - **Data Merging**: Merges global network data with local node information for complete stamp details
 - **Local Ownership Detection**: Identifies stamps owned/managed by the connected node
 - **Enhanced Field Mapping**: Handles different field names between global and local APIs
@@ -218,6 +219,7 @@ Swarm Connect is a FastAPI-based API gateway that provides comprehensive access 
 - **Data Merging Logic**: Combines global stamp data with local node information
 - **Field Mapping**: Handles different field names between endpoints (`immutable` vs `immutableFlag`)
 - **Usability Calculation**: Determines stamp usability based on TTL, depth, and immutability
+- **Utilization Calculation**: Computes stamp usage as percentage: `(utilization / 2^(depth-bucketDepth)) * 100`
 - **Local Detection**: Identifies stamps owned by the connected node
 
 #### Model Layer (`app/api/models/stamp.py`)

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -124,6 +124,7 @@ async def get_stamp_details(
             bucketDepth=found_stamp.get("bucketDepth"),
             batchTTL=found_stamp.get("batchTTL"),
             utilization=found_stamp.get("utilization"),
+            utilizationPercent=found_stamp.get("utilizationPercent"),
             usable=found_stamp.get("usable"),
             label=found_stamp.get("label"),
             expectedExpiration=found_stamp.get("expectedExpiration"),

--- a/app/api/models/stamp.py
+++ b/app/api/models/stamp.py
@@ -29,7 +29,8 @@ class StampDetails(BaseModel):
     batchTTL: int = Field(..., description="Original Time-To-Live in seconds (from API).") # Assuming always present
 
     # --- Fields enhanced with local stamp data ---
-    utilization: Optional[int] = Field(None, description="Stamp utilization (from local /stamps endpoint when available).")
+    utilization: Optional[int] = Field(None, description="Stamp utilization - raw bucket fill level (from local /stamps endpoint when available).")
+    utilizationPercent: Optional[float] = Field(None, description="Stamp utilization as percentage (0-100). Calculated as: (utilization / 2^(depth-bucketDepth)) * 100.")
     usable: Optional[bool] = Field(None, description="Stamp usability status (from local /stamps endpoint or calculated).")
     label: Optional[str] = Field(None, description="User-defined label (from local /stamps endpoint when available).")
 
@@ -50,11 +51,12 @@ class StampDetails(BaseModel):
                 "bucketDepth": 16,
                 "immutableFlag": False,     # Can be null
                 "batchTTL": 16971999,
-                "utilization": None,
-                "usable": None,
+                "utilization": 8,
+                "utilizationPercent": 50.0,
+                "usable": True,
                 "label": None,
                 "expectedExpiration": "2024-08-15-10-30",
-                "local": False
+                "local": True
             }
         }
 

--- a/tests/test_utilization_percent.py
+++ b/tests/test_utilization_percent.py
@@ -1,0 +1,251 @@
+# tests/test_utilization_percent.py
+"""Tests for utilization percentage calculation."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.services.swarm_api import calculate_utilization_percent
+
+
+class TestCalculateUtilizationPercent:
+    """Unit tests for the calculate_utilization_percent function."""
+
+    def test_basic_calculation(self):
+        """Test basic percentage calculation."""
+        # depth=17, bucketDepth=16 -> totalBuckets = 2^1 = 2
+        # utilization=1 -> 1/2 * 100 = 50%
+        result = calculate_utilization_percent(1, 17, 16)
+        assert result == 50.0
+
+    def test_full_utilization(self):
+        """Test 100% utilization."""
+        # depth=17, bucketDepth=16 -> totalBuckets = 2
+        # utilization=2 -> 2/2 * 100 = 100%
+        result = calculate_utilization_percent(2, 17, 16)
+        assert result == 100.0
+
+    def test_zero_utilization(self):
+        """Test 0% utilization."""
+        result = calculate_utilization_percent(0, 20, 16)
+        assert result == 0.0
+
+    def test_larger_depth_difference(self):
+        """Test with larger depth difference."""
+        # depth=20, bucketDepth=16 -> totalBuckets = 2^4 = 16
+        # utilization=4 -> 4/16 * 100 = 25%
+        result = calculate_utilization_percent(4, 20, 16)
+        assert result == 25.0
+
+    def test_depth_22(self):
+        """Test with depth 22."""
+        # depth=22, bucketDepth=16 -> totalBuckets = 2^6 = 64
+        # utilization=32 -> 32/64 * 100 = 50%
+        result = calculate_utilization_percent(32, 22, 16)
+        assert result == 50.0
+
+    def test_equal_depth_and_bucket_depth(self):
+        """Test when depth equals bucketDepth (1 bucket total)."""
+        # depth=16, bucketDepth=16 -> totalBuckets = 2^0 = 1
+        # utilization=1 -> 1/1 * 100 = 100%
+        result = calculate_utilization_percent(1, 16, 16)
+        assert result == 100.0
+
+    def test_partial_percent_rounded(self):
+        """Test that result is rounded to 2 decimal places."""
+        # depth=20, bucketDepth=16 -> totalBuckets = 16
+        # utilization=1 -> 1/16 * 100 = 6.25%
+        result = calculate_utilization_percent(1, 20, 16)
+        assert result == 6.25
+
+    def test_more_precision_rounding(self):
+        """Test rounding with values that produce more decimal places."""
+        # depth=20, bucketDepth=16 -> totalBuckets = 16
+        # utilization=3 -> 3/16 * 100 = 18.75%
+        result = calculate_utilization_percent(3, 20, 16)
+        assert result == 18.75
+
+    def test_capped_at_100(self):
+        """Test that result is capped at 100% (defensive)."""
+        # If somehow utilization > totalBuckets
+        # depth=17, bucketDepth=16 -> totalBuckets = 2
+        # utilization=5 -> would be 250%, capped to 100%
+        result = calculate_utilization_percent(5, 17, 16)
+        assert result == 100.0
+
+    def test_none_utilization(self):
+        """Test that None utilization returns None."""
+        result = calculate_utilization_percent(None, 20, 16)
+        assert result is None
+
+    def test_none_depth(self):
+        """Test that None depth returns None."""
+        result = calculate_utilization_percent(5, None, 16)
+        assert result is None
+
+    def test_none_bucket_depth(self):
+        """Test that None bucketDepth returns None."""
+        result = calculate_utilization_percent(5, 20, None)
+        assert result is None
+
+    def test_all_none(self):
+        """Test that all None values return None."""
+        result = calculate_utilization_percent(None, None, None)
+        assert result is None
+
+
+class TestUtilizationPercentInStampList:
+    """Integration tests for utilizationPercent in stamp list endpoint."""
+
+    @patch('app.services.swarm_api.get_all_stamps')
+    @patch('app.services.swarm_api.get_local_stamps')
+    def test_utilization_percent_in_processed_stamps(self, mock_local, mock_global):
+        """Test that get_all_stamps_processed includes utilizationPercent."""
+        from app.services.swarm_api import get_all_stamps_processed
+
+        mock_global.return_value = [
+            {
+                "batchID": "test123",
+                "depth": 17,
+                "bucketDepth": 16,
+                "batchTTL": 86400,
+                "amount": "1000000"
+            }
+        ]
+        mock_local.return_value = [
+            {
+                "batchID": "test123",
+                "utilization": 1,
+                "usable": True
+            }
+        ]
+
+        result = get_all_stamps_processed()
+
+        assert len(result) == 1
+        assert result[0]["utilizationPercent"] == 50.0
+        assert result[0]["utilization"] == 1
+
+    @patch('app.services.swarm_api.get_all_stamps')
+    @patch('app.services.swarm_api.get_local_stamps')
+    def test_utilization_percent_null_when_no_utilization(self, mock_local, mock_global):
+        """Test that utilizationPercent is None when utilization is not available."""
+        from app.services.swarm_api import get_all_stamps_processed
+
+        mock_global.return_value = [
+            {
+                "batchID": "test123",
+                "depth": 17,
+                "bucketDepth": 16,
+                "batchTTL": 86400,
+                "amount": "1000000"
+            }
+        ]
+        mock_local.return_value = []  # No local data
+
+        result = get_all_stamps_processed()
+
+        assert len(result) == 1
+        assert result[0]["utilizationPercent"] is None
+        assert result[0]["utilization"] is None
+
+
+class TestUtilizationPercentInAPI:
+    """Tests for utilizationPercent in API responses."""
+
+    @patch('app.services.swarm_api.get_all_stamps_processed')
+    def test_stamps_list_includes_utilization_percent(self, mock_processed):
+        """Test that /api/v1/stamps/ includes utilizationPercent."""
+        from fastapi.testclient import TestClient
+        from app.main import app
+
+        mock_processed.return_value = [
+            {
+                "batchID": "abc123",
+                "amount": "1000000",
+                "depth": 20,
+                "bucketDepth": 16,
+                "batchTTL": 86400,
+                "utilization": 4,
+                "utilizationPercent": 25.0,
+                "usable": True,
+                "label": None,
+                "blockNumber": None,
+                "owner": None,
+                "immutableFlag": None,
+                "expectedExpiration": "2025-01-01-00-00",
+                "local": True
+            }
+        ]
+
+        client = TestClient(app)
+        response = client.get("/api/v1/stamps/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["stamps"]) == 1
+        assert data["stamps"][0]["utilizationPercent"] == 25.0
+
+    @patch('app.services.swarm_api.get_all_stamps_processed')
+    def test_single_stamp_includes_utilization_percent(self, mock_processed):
+        """Test that /api/v1/stamps/{id} includes utilizationPercent."""
+        from fastapi.testclient import TestClient
+        from app.main import app
+
+        mock_processed.return_value = [
+            {
+                "batchID": "abc123",
+                "amount": "1000000",
+                "depth": 20,
+                "bucketDepth": 16,
+                "batchTTL": 86400,
+                "utilization": 8,
+                "utilizationPercent": 50.0,
+                "usable": True,
+                "label": None,
+                "blockNumber": None,
+                "owner": None,
+                "immutableFlag": None,
+                "expectedExpiration": "2025-01-01-00-00",
+                "local": True
+            }
+        ]
+
+        client = TestClient(app)
+        response = client.get("/api/v1/stamps/abc123")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["utilizationPercent"] == 50.0
+        assert data["utilization"] == 8
+
+    @patch('app.services.swarm_api.get_all_stamps_processed')
+    def test_utilization_percent_null_in_response(self, mock_processed):
+        """Test that utilizationPercent can be null in response."""
+        from fastapi.testclient import TestClient
+        from app.main import app
+
+        mock_processed.return_value = [
+            {
+                "batchID": "abc123",
+                "amount": "1000000",
+                "depth": 20,
+                "bucketDepth": 16,
+                "batchTTL": 86400,
+                "utilization": None,
+                "utilizationPercent": None,
+                "usable": None,
+                "label": None,
+                "blockNumber": None,
+                "owner": None,
+                "immutableFlag": None,
+                "expectedExpiration": "2025-01-01-00-00",
+                "local": False
+            }
+        ]
+
+        client = TestClient(app)
+        response = client.get("/api/v1/stamps/abc123")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["utilizationPercent"] is None
+        assert data["utilization"] is None


### PR DESCRIPTION
Closes #15

## Summary
- Add `calculate_utilization_percent()` function to calculate stamp usage as percentage
- Add `utilizationPercent` field to `StampDetails` model
- Include `utilizationPercent` in both stamp list and detail endpoints
- Add comprehensive tests (18 tests covering calculation and API)
- Update documentation

## Calculation
```
utilizationPercent = (utilization / 2^(depth - bucketDepth)) * 100
```

**Example:**
- depth=17, bucketDepth=16 → totalBuckets = 2
- utilization=1 → utilizationPercent = 50.0%

## API Response (before/after)

**Before:**
```json
{
  "utilization": 1,
  "depth": 17,
  "bucketDepth": 16
}
```

**After:**
```json
{
  "utilization": 1,
  "utilizationPercent": 50.0,
  "depth": 17,
  "bucketDepth": 16
}
```

## Edge Cases
- Returns `null` when utilization is unavailable
- Returns `null` when depth or bucketDepth is missing
- Capped at 100% (defensive)
- Rounded to 2 decimal places

## Test plan
- [x] Unit tests for `calculate_utilization_percent()` function
- [x] Integration tests for stamp list endpoint
- [x] Integration tests for single stamp endpoint
- [x] Edge case tests (null values, capping, rounding)