### PR TITLE
Implement x402 pre-flight balance checks (Issue #30)

### DIFF
--- a/app/x402/preflight.py
+++ b/app/x402/preflight.py
@@ -8,14 +8,190 @@ before accepting payment requests:
 - xDAI balance on Gnosis (for gas)
 - Chequebook balance (for bandwidth)
 
-TODO: Implementation pending - see Issue #2
+Balance thresholds are configured via environment variables in app/core/config.py.
 """
-from typing import Dict, Any
+import logging
+from typing import Dict, Any, List
+
+from app.core.config import settings
+from app.services.swarm_api import get_wallet_info, get_chequebook_balance
+
+logger = logging.getLogger(__name__)
+
+# Conversion constants
+PLUR_PER_BZZ = 10 ** 16  # 1 BZZ = 10^16 PLUR
+WEI_PER_XDAI = 10 ** 18  # 1 xDAI = 10^18 wei
+
+
+def plur_to_bzz(plur: int) -> float:
+    """Convert PLUR to BZZ."""
+    return plur / PLUR_PER_BZZ
+
+
+def wei_to_xdai(wei: int) -> float:
+    """Convert wei to xDAI."""
+    return wei / WEI_PER_XDAI
+
+
+def check_xbzz_balance() -> Dict[str, Any]:
+    """
+    Check xBZZ balance against configured threshold.
+
+    Returns:
+        Dict containing:
+        - ok: bool - whether balance is above threshold
+        - balance_plur: int - raw balance in PLUR
+        - balance_bzz: float - balance in BZZ
+        - threshold_bzz: float - warning threshold in BZZ
+        - warning: str or None - warning message if below threshold
+    """
+    try:
+        wallet_info = get_wallet_info()
+        balance_plur = int(wallet_info.get("bzzBalance", 0))
+        balance_bzz = plur_to_bzz(balance_plur)
+        threshold_bzz = settings.X402_XBZZ_WARN_THRESHOLD
+
+        warning = None
+        ok = balance_bzz >= threshold_bzz
+
+        if not ok:
+            warning = (
+                f"xBZZ balance ({balance_bzz:.4f} BZZ) is below threshold "
+                f"({threshold_bzz} BZZ). Top up your Gnosis wallet."
+            )
+            logger.warning(f"Pre-flight check: {warning}")
+
+        return {
+            "ok": ok,
+            "balance_plur": balance_plur,
+            "balance_bzz": balance_bzz,
+            "threshold_bzz": threshold_bzz,
+            "warning": warning
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to check xBZZ balance: {e}")
+        return {
+            "ok": False,
+            "balance_plur": 0,
+            "balance_bzz": 0.0,
+            "threshold_bzz": settings.X402_XBZZ_WARN_THRESHOLD,
+            "warning": f"Failed to fetch xBZZ balance: {str(e)}"
+        }
+
+
+def check_xdai_balance() -> Dict[str, Any]:
+    """
+    Check xDAI (native token) balance against configured threshold.
+
+    The Bee /wallet endpoint returns nativeTokenBalance which is xDAI on Gnosis chain.
+
+    Returns:
+        Dict containing:
+        - ok: bool - whether balance is above threshold
+        - balance_wei: int - raw balance in wei
+        - balance_xdai: float - balance in xDAI
+        - threshold_xdai: float - warning threshold in xDAI
+        - warning: str or None - warning message if below threshold
+    """
+    try:
+        wallet_info = get_wallet_info()
+        balance_wei = int(wallet_info.get("nativeTokenBalance", 0))
+        balance_xdai = wei_to_xdai(balance_wei)
+        threshold_xdai = settings.X402_XDAI_WARN_THRESHOLD
+
+        warning = None
+        ok = balance_xdai >= threshold_xdai
+
+        if not ok:
+            warning = (
+                f"xDAI balance ({balance_xdai:.4f} xDAI) is below threshold "
+                f"({threshold_xdai} xDAI). Top up your Gnosis wallet for gas."
+            )
+            logger.warning(f"Pre-flight check: {warning}")
+
+        return {
+            "ok": ok,
+            "balance_wei": balance_wei,
+            "balance_xdai": balance_xdai,
+            "threshold_xdai": threshold_xdai,
+            "warning": warning
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to check xDAI balance: {e}")
+        return {
+            "ok": False,
+            "balance_wei": 0,
+            "balance_xdai": 0.0,
+            "threshold_xdai": settings.X402_XDAI_WARN_THRESHOLD,
+            "warning": f"Failed to fetch xDAI balance: {str(e)}"
+        }
+
+
+def check_chequebook_balance() -> Dict[str, Any]:
+    """
+    Check chequebook balance against configured threshold.
+
+    The chequebook holds xBZZ for bandwidth payments.
+
+    Returns:
+        Dict containing:
+        - ok: bool - whether balance is above threshold
+        - available_balance_plur: int - available balance in PLUR
+        - available_balance_bzz: float - available balance in BZZ
+        - total_balance_plur: int - total balance in PLUR
+        - total_balance_bzz: float - total balance in BZZ
+        - threshold_bzz: float - warning threshold in BZZ
+        - warning: str or None - warning message if below threshold
+    """
+    try:
+        chequebook_info = get_chequebook_balance()
+        available_plur = int(chequebook_info.get("availableBalance", 0))
+        total_plur = int(chequebook_info.get("totalBalance", 0))
+        available_bzz = plur_to_bzz(available_plur)
+        total_bzz = plur_to_bzz(total_plur)
+        threshold_bzz = settings.X402_CHEQUEBOOK_WARN_THRESHOLD
+
+        warning = None
+        ok = available_bzz >= threshold_bzz
+
+        if not ok:
+            warning = (
+                f"Chequebook available balance ({available_bzz:.4f} BZZ) is below threshold "
+                f"({threshold_bzz} BZZ). Top up your chequebook for bandwidth payments."
+            )
+            logger.warning(f"Pre-flight check: {warning}")
+
+        return {
+            "ok": ok,
+            "available_balance_plur": available_plur,
+            "available_balance_bzz": available_bzz,
+            "total_balance_plur": total_plur,
+            "total_balance_bzz": total_bzz,
+            "threshold_bzz": threshold_bzz,
+            "warning": warning
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to check chequebook balance: {e}")
+        return {
+            "ok": False,
+            "available_balance_plur": 0,
+            "available_balance_bzz": 0.0,
+            "total_balance_plur": 0,
+            "total_balance_bzz": 0.0,
+            "threshold_bzz": settings.X402_CHEQUEBOOK_WARN_THRESHOLD,
+            "warning": f"Failed to fetch chequebook balance: {str(e)}"
+        }
 
 
 def check_preflight_balances() -> Dict[str, Any]:
     """
     Check all gateway balances and return pass/fail status.
+
+    This is the main entry point for pre-flight checks before accepting
+    x402 payment requests.
 
     Returns:
         Dict containing:
@@ -26,6 +202,70 @@ def check_preflight_balances() -> Dict[str, Any]:
         - balances: dict - current balance values
         - warnings: list - non-blocking warnings
         - errors: list - blocking errors
+
+    The gateway can still accept payments if there are warnings,
+    but not if there are errors.
     """
-    # TODO: Implement actual balance checks
-    raise NotImplementedError("Pre-flight checks not yet implemented - see Issue #2")
+    warnings: List[str] = []
+    errors: List[str] = []
+
+    # Check all balances
+    xbzz_result = check_xbzz_balance()
+    xdai_result = check_xdai_balance()
+    chequebook_result = check_chequebook_balance()
+
+    # Collect warnings from each check
+    if xbzz_result.get("warning"):
+        warnings.append(xbzz_result["warning"])
+    if xdai_result.get("warning"):
+        warnings.append(xdai_result["warning"])
+    if chequebook_result.get("warning"):
+        warnings.append(chequebook_result["warning"])
+
+    # Determine if we can accept payments
+    # All checks must pass to accept payments
+    xbzz_ok = xbzz_result["ok"]
+    xdai_ok = xdai_result["ok"]
+    chequebook_ok = chequebook_result["ok"]
+
+    # Build error messages for complete failures (e.g., API errors)
+    if xbzz_result["balance_bzz"] == 0.0 and "Failed to fetch" in str(xbzz_result.get("warning", "")):
+        errors.append("Cannot verify xBZZ balance - Bee node may be unreachable")
+    if xdai_result["balance_xdai"] == 0.0 and "Failed to fetch" in str(xdai_result.get("warning", "")):
+        errors.append("Cannot verify xDAI balance - Bee node may be unreachable")
+    if chequebook_result["available_balance_bzz"] == 0.0 and "Failed to fetch" in str(chequebook_result.get("warning", "")):
+        errors.append("Cannot verify chequebook balance - Bee node may be unreachable")
+
+    # Can accept if all checks pass OR if they fail only due to low balance (not API errors)
+    # Low balance is a warning, not a blocking error for now
+    can_accept = len(errors) == 0
+
+    logger.info(
+        f"Pre-flight check complete: can_accept={can_accept}, "
+        f"xbzz_ok={xbzz_ok}, xdai_ok={xdai_ok}, chequebook_ok={chequebook_ok}, "
+        f"warnings={len(warnings)}, errors={len(errors)}"
+    )
+
+    return {
+        "can_accept": can_accept,
+        "xbzz_ok": xbzz_ok,
+        "xdai_ok": xdai_ok,
+        "chequebook_ok": chequebook_ok,
+        "balances": {
+            "xbzz": {
+                "balance_bzz": xbzz_result["balance_bzz"],
+                "threshold_bzz": xbzz_result["threshold_bzz"]
+            },
+            "xdai": {
+                "balance_xdai": xdai_result["balance_xdai"],
+                "threshold_xdai": xdai_result["threshold_xdai"]
+            },
+            "chequebook": {
+                "available_bzz": chequebook_result["available_balance_bzz"],
+                "total_bzz": chequebook_result["total_balance_bzz"],
+                "threshold_bzz": chequebook_result["threshold_bzz"]
+            }
+        },
+        "warnings": warnings,
+        "errors": errors
+    }

--- a/tests/test_x402_preflight.py
+++ b/tests/test_x402_preflight.py
@@ -1,0 +1,417 @@
+# tests/test_x402_preflight.py
+"""
+Unit tests for x402 pre-flight balance checks.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.x402.preflight import (
+    plur_to_bzz,
+    wei_to_xdai,
+    check_xbzz_balance,
+    check_xdai_balance,
+    check_chequebook_balance,
+    check_preflight_balances,
+    PLUR_PER_BZZ,
+    WEI_PER_XDAI,
+)
+
+
+class TestConversionFunctions:
+    """Test unit conversion functions."""
+
+    def test_plur_to_bzz_zero(self):
+        """Zero PLUR equals zero BZZ."""
+        assert plur_to_bzz(0) == 0.0
+
+    def test_plur_to_bzz_one_bzz(self):
+        """One BZZ worth of PLUR."""
+        assert plur_to_bzz(PLUR_PER_BZZ) == 1.0
+
+    def test_plur_to_bzz_fractional(self):
+        """Fractional BZZ values."""
+        assert plur_to_bzz(PLUR_PER_BZZ // 2) == 0.5
+
+    def test_wei_to_xdai_zero(self):
+        """Zero wei equals zero xDAI."""
+        assert wei_to_xdai(0) == 0.0
+
+    def test_wei_to_xdai_one_xdai(self):
+        """One xDAI worth of wei."""
+        assert wei_to_xdai(WEI_PER_XDAI) == 1.0
+
+    def test_wei_to_xdai_fractional(self):
+        """Fractional xDAI values."""
+        assert wei_to_xdai(WEI_PER_XDAI // 2) == 0.5
+
+
+class TestCheckXBZZBalance:
+    """Test xBZZ balance checks."""
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xbzz_above_threshold(self, mock_settings, mock_get_wallet):
+        """xBZZ balance above threshold returns ok=True."""
+        mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            "bzzBalance": str(20 * PLUR_PER_BZZ)  # 20 BZZ
+        }
+
+        result = check_xbzz_balance()
+
+        assert result["ok"] is True
+        assert result["balance_bzz"] == 20.0
+        assert result["threshold_bzz"] == 10.0
+        assert result["warning"] is None
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xbzz_below_threshold(self, mock_settings, mock_get_wallet):
+        """xBZZ balance below threshold returns ok=False with warning."""
+        mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            "bzzBalance": str(5 * PLUR_PER_BZZ)  # 5 BZZ
+        }
+
+        result = check_xbzz_balance()
+
+        assert result["ok"] is False
+        assert result["balance_bzz"] == 5.0
+        assert result["threshold_bzz"] == 10.0
+        assert "below threshold" in result["warning"]
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xbzz_at_exact_threshold(self, mock_settings, mock_get_wallet):
+        """xBZZ balance exactly at threshold returns ok=True."""
+        mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            "bzzBalance": str(10 * PLUR_PER_BZZ)  # 10 BZZ
+        }
+
+        result = check_xbzz_balance()
+
+        assert result["ok"] is True
+        assert result["balance_bzz"] == 10.0
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xbzz_api_error(self, mock_settings, mock_get_wallet):
+        """API error returns ok=False with error message."""
+        mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
+        mock_get_wallet.side_effect = Exception("Connection refused")
+
+        result = check_xbzz_balance()
+
+        assert result["ok"] is False
+        assert result["balance_bzz"] == 0.0
+        assert "Failed to fetch" in result["warning"]
+
+
+class TestCheckXDAIBalance:
+    """Test xDAI balance checks."""
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xdai_above_threshold(self, mock_settings, mock_get_wallet):
+        """xDAI balance above threshold returns ok=True."""
+        mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            "nativeTokenBalance": str(int(1.0 * WEI_PER_XDAI))  # 1 xDAI
+        }
+
+        result = check_xdai_balance()
+
+        assert result["ok"] is True
+        assert result["balance_xdai"] == 1.0
+        assert result["threshold_xdai"] == 0.5
+        assert result["warning"] is None
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xdai_below_threshold(self, mock_settings, mock_get_wallet):
+        """xDAI balance below threshold returns ok=False with warning."""
+        mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            "nativeTokenBalance": str(int(0.1 * WEI_PER_XDAI))  # 0.1 xDAI
+        }
+
+        result = check_xdai_balance()
+
+        assert result["ok"] is False
+        assert result["balance_xdai"] == 0.1
+        assert "below threshold" in result["warning"]
+        assert "gas" in result["warning"].lower()
+
+    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.settings")
+    def test_xdai_missing_field(self, mock_settings, mock_get_wallet):
+        """Missing nativeTokenBalance field defaults to 0."""
+        mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
+        mock_get_wallet.return_value = {
+            "walletAddress": "0x123",
+            # nativeTokenBalance missing
+        }
+
+        result = check_xdai_balance()
+
+        assert result["ok"] is False
+        assert result["balance_xdai"] == 0.0
+
+
+class TestCheckChequebookBalance:
+    """Test chequebook balance checks."""
+
+    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.settings")
+    def test_chequebook_above_threshold(self, mock_settings, mock_get_chequebook):
+        """Chequebook balance above threshold returns ok=True."""
+        mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
+        mock_get_chequebook.return_value = {
+            "availableBalance": str(10 * PLUR_PER_BZZ),  # 10 BZZ
+            "totalBalance": str(15 * PLUR_PER_BZZ)  # 15 BZZ
+        }
+
+        result = check_chequebook_balance()
+
+        assert result["ok"] is True
+        assert result["available_balance_bzz"] == 10.0
+        assert result["total_balance_bzz"] == 15.0
+        assert result["threshold_bzz"] == 5.0
+        assert result["warning"] is None
+
+    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.settings")
+    def test_chequebook_below_threshold(self, mock_settings, mock_get_chequebook):
+        """Chequebook balance below threshold returns ok=False with warning."""
+        mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
+        mock_get_chequebook.return_value = {
+            "availableBalance": str(2 * PLUR_PER_BZZ),  # 2 BZZ
+            "totalBalance": str(5 * PLUR_PER_BZZ)  # 5 BZZ
+        }
+
+        result = check_chequebook_balance()
+
+        assert result["ok"] is False
+        assert result["available_balance_bzz"] == 2.0
+        assert "below threshold" in result["warning"]
+        assert "bandwidth" in result["warning"].lower()
+
+    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.settings")
+    def test_chequebook_api_error(self, mock_settings, mock_get_chequebook):
+        """API error returns ok=False with error message."""
+        mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
+        mock_get_chequebook.side_effect = Exception("Connection refused")
+
+        result = check_chequebook_balance()
+
+        assert result["ok"] is False
+        assert result["available_balance_bzz"] == 0.0
+        assert "Failed to fetch" in result["warning"]
+
+
+class TestCheckPreflightBalances:
+    """Test combined pre-flight balance checks."""
+
+    @patch("app.x402.preflight.check_chequebook_balance")
+    @patch("app.x402.preflight.check_xdai_balance")
+    @patch("app.x402.preflight.check_xbzz_balance")
+    def test_all_checks_pass(self, mock_xbzz, mock_xdai, mock_chequebook):
+        """All checks passing returns can_accept=True."""
+        mock_xbzz.return_value = {
+            "ok": True,
+            "balance_plur": 20 * PLUR_PER_BZZ,
+            "balance_bzz": 20.0,
+            "threshold_bzz": 10.0,
+            "warning": None
+        }
+        mock_xdai.return_value = {
+            "ok": True,
+            "balance_wei": int(1.0 * WEI_PER_XDAI),
+            "balance_xdai": 1.0,
+            "threshold_xdai": 0.5,
+            "warning": None
+        }
+        mock_chequebook.return_value = {
+            "ok": True,
+            "available_balance_plur": 10 * PLUR_PER_BZZ,
+            "available_balance_bzz": 10.0,
+            "total_balance_plur": 15 * PLUR_PER_BZZ,
+            "total_balance_bzz": 15.0,
+            "threshold_bzz": 5.0,
+            "warning": None
+        }
+
+        result = check_preflight_balances()
+
+        assert result["can_accept"] is True
+        assert result["xbzz_ok"] is True
+        assert result["xdai_ok"] is True
+        assert result["chequebook_ok"] is True
+        assert len(result["warnings"]) == 0
+        assert len(result["errors"]) == 0
+
+    @patch("app.x402.preflight.check_chequebook_balance")
+    @patch("app.x402.preflight.check_xdai_balance")
+    @patch("app.x402.preflight.check_xbzz_balance")
+    def test_low_balance_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
+        """Low balances generate warnings but can still accept."""
+        mock_xbzz.return_value = {
+            "ok": False,
+            "balance_plur": 5 * PLUR_PER_BZZ,
+            "balance_bzz": 5.0,
+            "threshold_bzz": 10.0,
+            "warning": "xBZZ balance below threshold"
+        }
+        mock_xdai.return_value = {
+            "ok": True,
+            "balance_wei": int(1.0 * WEI_PER_XDAI),
+            "balance_xdai": 1.0,
+            "threshold_xdai": 0.5,
+            "warning": None
+        }
+        mock_chequebook.return_value = {
+            "ok": True,
+            "available_balance_plur": 10 * PLUR_PER_BZZ,
+            "available_balance_bzz": 10.0,
+            "total_balance_plur": 15 * PLUR_PER_BZZ,
+            "total_balance_bzz": 15.0,
+            "threshold_bzz": 5.0,
+            "warning": None
+        }
+
+        result = check_preflight_balances()
+
+        # Can accept even with low balance (warning only)
+        assert result["can_accept"] is True
+        assert result["xbzz_ok"] is False
+        assert len(result["warnings"]) == 1
+        assert len(result["errors"]) == 0
+
+    @patch("app.x402.preflight.check_chequebook_balance")
+    @patch("app.x402.preflight.check_xdai_balance")
+    @patch("app.x402.preflight.check_xbzz_balance")
+    def test_api_error_blocks_acceptance(self, mock_xbzz, mock_xdai, mock_chequebook):
+        """API errors block payment acceptance."""
+        mock_xbzz.return_value = {
+            "ok": False,
+            "balance_plur": 0,
+            "balance_bzz": 0.0,
+            "threshold_bzz": 10.0,
+            "warning": "Failed to fetch xBZZ balance: Connection refused"
+        }
+        mock_xdai.return_value = {
+            "ok": True,
+            "balance_wei": int(1.0 * WEI_PER_XDAI),
+            "balance_xdai": 1.0,
+            "threshold_xdai": 0.5,
+            "warning": None
+        }
+        mock_chequebook.return_value = {
+            "ok": True,
+            "available_balance_plur": 10 * PLUR_PER_BZZ,
+            "available_balance_bzz": 10.0,
+            "total_balance_plur": 15 * PLUR_PER_BZZ,
+            "total_balance_bzz": 15.0,
+            "threshold_bzz": 5.0,
+            "warning": None
+        }
+
+        result = check_preflight_balances()
+
+        # Cannot accept when API is unreachable
+        assert result["can_accept"] is False
+        assert len(result["errors"]) == 1
+        assert "unreachable" in result["errors"][0].lower()
+
+    @patch("app.x402.preflight.check_chequebook_balance")
+    @patch("app.x402.preflight.check_xdai_balance")
+    @patch("app.x402.preflight.check_xbzz_balance")
+    def test_balances_structure(self, mock_xbzz, mock_xdai, mock_chequebook):
+        """Verify balances structure in response."""
+        mock_xbzz.return_value = {
+            "ok": True,
+            "balance_plur": 20 * PLUR_PER_BZZ,
+            "balance_bzz": 20.0,
+            "threshold_bzz": 10.0,
+            "warning": None
+        }
+        mock_xdai.return_value = {
+            "ok": True,
+            "balance_wei": int(1.0 * WEI_PER_XDAI),
+            "balance_xdai": 1.0,
+            "threshold_xdai": 0.5,
+            "warning": None
+        }
+        mock_chequebook.return_value = {
+            "ok": True,
+            "available_balance_plur": 10 * PLUR_PER_BZZ,
+            "available_balance_bzz": 10.0,
+            "total_balance_plur": 15 * PLUR_PER_BZZ,
+            "total_balance_bzz": 15.0,
+            "threshold_bzz": 5.0,
+            "warning": None
+        }
+
+        result = check_preflight_balances()
+
+        # Verify balances structure
+        assert "balances" in result
+        assert "xbzz" in result["balances"]
+        assert "xdai" in result["balances"]
+        assert "chequebook" in result["balances"]
+
+        assert result["balances"]["xbzz"]["balance_bzz"] == 20.0
+        assert result["balances"]["xbzz"]["threshold_bzz"] == 10.0
+
+        assert result["balances"]["xdai"]["balance_xdai"] == 1.0
+        assert result["balances"]["xdai"]["threshold_xdai"] == 0.5
+
+        assert result["balances"]["chequebook"]["available_bzz"] == 10.0
+        assert result["balances"]["chequebook"]["total_bzz"] == 15.0
+        assert result["balances"]["chequebook"]["threshold_bzz"] == 5.0
+
+    @patch("app.x402.preflight.check_chequebook_balance")
+    @patch("app.x402.preflight.check_xdai_balance")
+    @patch("app.x402.preflight.check_xbzz_balance")
+    def test_multiple_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
+        """Multiple low balances generate multiple warnings."""
+        mock_xbzz.return_value = {
+            "ok": False,
+            "balance_plur": 5 * PLUR_PER_BZZ,
+            "balance_bzz": 5.0,
+            "threshold_bzz": 10.0,
+            "warning": "xBZZ below threshold"
+        }
+        mock_xdai.return_value = {
+            "ok": False,
+            "balance_wei": int(0.1 * WEI_PER_XDAI),
+            "balance_xdai": 0.1,
+            "threshold_xdai": 0.5,
+            "warning": "xDAI below threshold"
+        }
+        mock_chequebook.return_value = {
+            "ok": False,
+            "available_balance_plur": 2 * PLUR_PER_BZZ,
+            "available_balance_bzz": 2.0,
+            "total_balance_plur": 5 * PLUR_PER_BZZ,
+            "total_balance_bzz": 5.0,
+            "threshold_bzz": 5.0,
+            "warning": "Chequebook below threshold"
+        }
+
+        result = check_preflight_balances()
+
+        # Can still accept (low balance = warning, not error)
+        assert result["can_accept"] is True
+        assert result["xbzz_ok"] is False
+        assert result["xdai_ok"] is False
+        assert result["chequebook_ok"] is False
+        assert len(result["warnings"]) == 3
+        assert len(result["errors"]) == 0


### PR DESCRIPTION
## Summary

Implements pre-flight balance verification for the x402 payment system. Before accepting payment requests, the gateway checks:

- **xBZZ balance** on Gnosis (for stamp purchases) - reuses existing `get_wallet_info()` 
- **xDAI balance** on Gnosis (for gas) - uses `nativeTokenBalance` from Bee /wallet endpoint
- **Chequebook balance** (for bandwidth) - reuses existing `get_chequebook_balance()`

### Key Features

- Configurable thresholds via environment variables:
  - `X402_XBZZ_WARN_THRESHOLD` (default: 10 BZZ)
  - `X402_XDAI_WARN_THRESHOLD` (default: 0.5 xDAI)
  - `X402_CHEQUEBOOK_WARN_THRESHOLD` (default: 5 BZZ)

- Structured response with:
  - `can_accept`: Whether gateway can accept payments
  - Individual check results (`xbzz_ok`, `xdai_ok`, `chequebook_ok`)
  - Current balance values with thresholds
  - `warnings`: Non-blocking issues (low balances)
  - `errors`: Blocking issues (API unreachable)

- Behavior:
  - API errors → block acceptance (safety first)
  - Low balances → generate warnings but allow acceptance

### Files Changed

- `app/x402/preflight.py` - Full implementation replacing placeholder
- `tests/test_x402_preflight.py` - 21 comprehensive unit tests

### Test Plan

- [x] All 21 unit tests pass
- [x] Tests cover: conversion functions, individual balance checks, combined preflight checks
- [x] Edge cases tested: exact thresholds, API errors, missing fields, multiple warnings

Closes #30

Part of x402 payment integration (Issue #29)