### PR TITLE
Implement x402 access control (Issue #33)

### DIFF
--- a/app/x402/access.py
+++ b/app/x402/access.py
@@ -1,14 +1,146 @@
 # app/x402/access.py
 """
-Access control for x402 payments (whitelist/blacklist).
+Access control for x402 payment gateway.
 
-This module handles IP-based and wallet-based access control:
-- Blacklist: Block specific IPs or wallets (403 Forbidden)
-- Whitelist: Allow free access for specific IPs or wallets (bypass x402)
+This module provides IP-based access control:
+- Blacklist: Block specific IPs from using the gateway
+- Whitelist: Allow specific IPs to bypass x402 payment requirements
 
-TODO: Implementation pending - see Issue #5
+Configuration is loaded from app/core/config.py:
+- X402_BLACKLIST_IPS: Comma-separated list of blocked IPs
+- X402_WHITELIST_IPS: Comma-separated list of IPs that bypass payment
 """
-from typing import Tuple, Optional
+import logging
+import ipaddress
+from typing import Optional, Set, Tuple
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def parse_ip_list(ip_string: Optional[str]) -> Set[str]:
+    """
+    Parse a comma-separated IP list into a set.
+
+    Handles:
+    - Individual IPs: "192.168.1.1"
+    - CIDR notation: "192.168.0.0/24"
+    - Whitespace trimming
+
+    Args:
+        ip_string: Comma-separated IP addresses/ranges
+
+    Returns:
+        Set of normalized IP strings/CIDR ranges
+    """
+    if not ip_string or not ip_string.strip():
+        return set()
+
+    result = set()
+    for item in ip_string.split(","):
+        item = item.strip()
+        if not item:
+            continue
+
+        # Validate and normalize the IP/CIDR
+        try:
+            if "/" in item:
+                # CIDR notation
+                network = ipaddress.ip_network(item, strict=False)
+                result.add(str(network))
+            else:
+                # Single IP
+                ip = ipaddress.ip_address(item)
+                result.add(str(ip))
+        except ValueError as e:
+            logger.warning(f"Invalid IP address/range in config: {item} - {e}")
+            continue
+
+    return result
+
+
+def ip_matches_list(client_ip: str, ip_list: Set[str]) -> bool:
+    """
+    Check if a client IP matches any entry in the IP list.
+
+    Supports:
+    - Exact IP match
+    - CIDR range matching
+
+    Args:
+        client_ip: The client's IP address
+        ip_list: Set of IPs/CIDR ranges to check against
+
+    Returns:
+        True if the client IP matches any entry
+    """
+    if not ip_list:
+        return False
+
+    try:
+        client = ipaddress.ip_address(client_ip)
+    except ValueError:
+        logger.warning(f"Invalid client IP address: {client_ip}")
+        return False
+
+    for entry in ip_list:
+        try:
+            if "/" in entry:
+                # CIDR range check
+                network = ipaddress.ip_network(entry, strict=False)
+                if client in network:
+                    return True
+            else:
+                # Exact match
+                if str(client) == entry:
+                    return True
+        except ValueError:
+            continue
+
+    return False
+
+
+def is_ip_blacklisted(client_ip: str) -> bool:
+    """
+    Check if a client IP is blacklisted.
+
+    Blacklisted IPs are completely blocked from using the gateway.
+
+    Args:
+        client_ip: The client's IP address
+
+    Returns:
+        True if the IP is blacklisted
+    """
+    blacklist = parse_ip_list(settings.X402_BLACKLIST_IPS)
+    is_blocked = ip_matches_list(client_ip, blacklist)
+
+    if is_blocked:
+        logger.warning(f"Blocked blacklisted IP: {client_ip}")
+
+    return is_blocked
+
+
+def is_ip_whitelisted(client_ip: str) -> bool:
+    """
+    Check if a client IP is whitelisted.
+
+    Whitelisted IPs can bypass x402 payment requirements.
+
+    Args:
+        client_ip: The client's IP address
+
+    Returns:
+        True if the IP is whitelisted
+    """
+    whitelist = parse_ip_list(settings.X402_WHITELIST_IPS)
+    is_allowed = ip_matches_list(client_ip, whitelist)
+
+    if is_allowed:
+        logger.info(f"Allowing whitelisted IP to bypass payment: {client_ip}")
+
+    return is_allowed
 
 
 def check_access(
@@ -18,9 +150,11 @@ def check_access(
     """
     Check if a client is allowed to access the service.
 
+    This is the main entry point for access control in the middleware.
+
     Args:
         client_ip: Client's IP address
-        wallet_address: Optional wallet address from payment signature
+        wallet_address: Optional wallet address from payment signature (reserved for future use)
 
     Returns:
         Tuple of (access_status, reason):
@@ -28,17 +162,33 @@ def check_access(
         - ("free", None) - Client is whitelisted (free access)
         - ("pay", None) - Client must pay via x402
     """
-    # TODO: Implement actual access control
-    raise NotImplementedError("Access control not yet implemented - see Issue #5")
+    # First check blacklist - blocked IPs cannot proceed at all
+    if is_ip_blacklisted(client_ip):
+        return ("blocked", "IP address is blocked")
+
+    # Check whitelist - whitelisted IPs bypass payment
+    if is_ip_whitelisted(client_ip):
+        return ("free", None)
+
+    # Normal access - requires payment
+    return ("pay", None)
 
 
-def is_ip_blacklisted(ip: str) -> bool:
-    """Check if an IP is in the blacklist."""
-    # TODO: Implement
-    raise NotImplementedError("Access control not yet implemented - see Issue #5")
+def get_access_control_status() -> dict:
+    """
+    Get current access control configuration status.
 
+    Useful for diagnostics and admin endpoints.
 
-def is_ip_whitelisted(ip: str) -> bool:
-    """Check if an IP is in the whitelist (free access)."""
-    # TODO: Implement
-    raise NotImplementedError("Access control not yet implemented - see Issue #5")
+    Returns:
+        Dict with blacklist and whitelist info
+    """
+    blacklist = parse_ip_list(settings.X402_BLACKLIST_IPS)
+    whitelist = parse_ip_list(settings.X402_WHITELIST_IPS)
+
+    return {
+        "blacklist_count": len(blacklist),
+        "whitelist_count": len(whitelist),
+        "blacklist_entries": sorted(list(blacklist)),
+        "whitelist_entries": sorted(list(whitelist)),
+    }

--- a/tests/test_x402_access.py
+++ b/tests/test_x402_access.py
@@ -1,0 +1,336 @@
+# tests/test_x402_access.py
+"""
+Unit tests for x402 access control (whitelist/blacklist).
+"""
+import pytest
+from unittest.mock import patch
+
+from app.x402.access import (
+    parse_ip_list,
+    ip_matches_list,
+    is_ip_blacklisted,
+    is_ip_whitelisted,
+    check_access,
+    get_access_control_status,
+)
+
+
+class TestParseIPList:
+    """Test IP list parsing."""
+
+    def test_parse_empty_string(self):
+        """Empty string returns empty set."""
+        assert parse_ip_list("") == set()
+        assert parse_ip_list(None) == set()
+        assert parse_ip_list("   ") == set()
+
+    def test_parse_single_ip(self):
+        """Parse single IP address."""
+        result = parse_ip_list("192.168.1.1")
+        assert "192.168.1.1" in result
+        assert len(result) == 1
+
+    def test_parse_multiple_ips(self):
+        """Parse comma-separated IPs."""
+        result = parse_ip_list("192.168.1.1, 10.0.0.1, 172.16.0.1")
+        assert "192.168.1.1" in result
+        assert "10.0.0.1" in result
+        assert "172.16.0.1" in result
+        assert len(result) == 3
+
+    def test_parse_cidr_notation(self):
+        """Parse CIDR notation."""
+        result = parse_ip_list("192.168.0.0/24")
+        assert "192.168.0.0/24" in result
+
+    def test_parse_mixed_ips_and_cidrs(self):
+        """Parse mixed IPs and CIDR ranges."""
+        result = parse_ip_list("192.168.1.1, 10.0.0.0/8, 172.16.0.1")
+        assert "192.168.1.1" in result
+        assert "10.0.0.0/8" in result
+        assert "172.16.0.1" in result
+        assert len(result) == 3
+
+    def test_parse_with_whitespace(self):
+        """Handle whitespace in list."""
+        result = parse_ip_list("  192.168.1.1  ,  10.0.0.1  ")
+        assert "192.168.1.1" in result
+        assert "10.0.0.1" in result
+
+    def test_parse_invalid_ip_ignored(self):
+        """Invalid IPs are skipped."""
+        result = parse_ip_list("192.168.1.1, invalid, 10.0.0.1")
+        assert "192.168.1.1" in result
+        assert "10.0.0.1" in result
+        assert len(result) == 2
+
+    def test_parse_ipv6(self):
+        """Parse IPv6 addresses."""
+        result = parse_ip_list("::1, 2001:db8::1")
+        assert "::1" in result
+        assert "2001:db8::1" in result
+
+    def test_parse_ipv6_cidr(self):
+        """Parse IPv6 CIDR notation."""
+        result = parse_ip_list("2001:db8::/32")
+        assert "2001:db8::/32" in result
+
+
+class TestIPMatchesList:
+    """Test IP matching against lists."""
+
+    def test_exact_match(self):
+        """Exact IP match."""
+        ip_list = {"192.168.1.1", "10.0.0.1"}
+        assert ip_matches_list("192.168.1.1", ip_list) is True
+        assert ip_matches_list("10.0.0.1", ip_list) is True
+        assert ip_matches_list("192.168.1.2", ip_list) is False
+
+    def test_cidr_match(self):
+        """CIDR range matching."""
+        ip_list = {"192.168.0.0/24"}
+        assert ip_matches_list("192.168.0.1", ip_list) is True
+        assert ip_matches_list("192.168.0.254", ip_list) is True
+        assert ip_matches_list("192.168.1.1", ip_list) is False
+
+    def test_mixed_match(self):
+        """Mixed exact and CIDR matching."""
+        ip_list = {"192.168.1.1", "10.0.0.0/8"}
+        assert ip_matches_list("192.168.1.1", ip_list) is True
+        assert ip_matches_list("10.5.5.5", ip_list) is True
+        assert ip_matches_list("192.168.2.1", ip_list) is False
+
+    def test_empty_list(self):
+        """Empty list never matches."""
+        assert ip_matches_list("192.168.1.1", set()) is False
+
+    def test_invalid_client_ip(self):
+        """Invalid client IP returns False."""
+        ip_list = {"192.168.1.1"}
+        assert ip_matches_list("invalid", ip_list) is False
+        assert ip_matches_list("", ip_list) is False
+
+    def test_ipv6_match(self):
+        """IPv6 address matching."""
+        ip_list = {"::1", "2001:db8::/32"}
+        assert ip_matches_list("::1", ip_list) is True
+        assert ip_matches_list("2001:db8::1", ip_list) is True
+        assert ip_matches_list("2001:db9::1", ip_list) is False
+
+
+class TestIsIPBlacklisted:
+    """Test blacklist checking."""
+
+    @patch("app.x402.access.settings")
+    def test_blacklisted_ip(self, mock_settings):
+        """Blacklisted IP returns True."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.100, 10.0.0.0/8"
+
+        assert is_ip_blacklisted("192.168.1.100") is True
+        assert is_ip_blacklisted("10.5.5.5") is True
+
+    @patch("app.x402.access.settings")
+    def test_not_blacklisted_ip(self, mock_settings):
+        """Non-blacklisted IP returns False."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.100"
+
+        assert is_ip_blacklisted("192.168.1.101") is False
+        assert is_ip_blacklisted("10.0.0.1") is False
+
+    @patch("app.x402.access.settings")
+    def test_empty_blacklist(self, mock_settings):
+        """Empty blacklist never matches."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+
+        assert is_ip_blacklisted("192.168.1.1") is False
+
+    @patch("app.x402.access.settings")
+    def test_none_blacklist(self, mock_settings):
+        """None blacklist never matches."""
+        mock_settings.X402_BLACKLIST_IPS = None
+
+        assert is_ip_blacklisted("192.168.1.1") is False
+
+
+class TestIsIPWhitelisted:
+    """Test whitelist checking."""
+
+    @patch("app.x402.access.settings")
+    def test_whitelisted_ip(self, mock_settings):
+        """Whitelisted IP returns True."""
+        mock_settings.X402_WHITELIST_IPS = "192.168.1.50, 172.16.0.0/12"
+
+        assert is_ip_whitelisted("192.168.1.50") is True
+        assert is_ip_whitelisted("172.20.0.1") is True
+
+    @patch("app.x402.access.settings")
+    def test_not_whitelisted_ip(self, mock_settings):
+        """Non-whitelisted IP returns False."""
+        mock_settings.X402_WHITELIST_IPS = "192.168.1.50"
+
+        assert is_ip_whitelisted("192.168.1.51") is False
+
+    @patch("app.x402.access.settings")
+    def test_empty_whitelist(self, mock_settings):
+        """Empty whitelist never matches."""
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        assert is_ip_whitelisted("192.168.1.1") is False
+
+
+class TestCheckAccess:
+    """Test the main check_access function."""
+
+    @patch("app.x402.access.settings")
+    def test_blacklisted_returns_blocked(self, mock_settings):
+        """Blacklisted IP returns 'blocked' status."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.100"
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status, reason = check_access("192.168.1.100")
+        assert status == "blocked"
+        assert reason == "IP address is blocked"
+
+    @patch("app.x402.access.settings")
+    def test_whitelisted_returns_free(self, mock_settings):
+        """Whitelisted IP returns 'free' status."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = "192.168.1.50"
+
+        status, reason = check_access("192.168.1.50")
+        assert status == "free"
+        assert reason is None
+
+    @patch("app.x402.access.settings")
+    def test_normal_returns_pay(self, mock_settings):
+        """Normal IP returns 'pay' status."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status, reason = check_access("192.168.1.1")
+        assert status == "pay"
+        assert reason is None
+
+    @patch("app.x402.access.settings")
+    def test_blacklist_takes_precedence_over_whitelist(self, mock_settings):
+        """If IP is in both lists, blacklist takes precedence."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.100"
+        mock_settings.X402_WHITELIST_IPS = "192.168.1.100"
+
+        status, reason = check_access("192.168.1.100")
+        assert status == "blocked"
+
+    @patch("app.x402.access.settings")
+    def test_cidr_blacklist(self, mock_settings):
+        """CIDR range blacklisting."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.0.0/16"
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status, _ = check_access("192.168.50.100")
+        assert status == "blocked"
+
+        status, _ = check_access("10.0.0.1")
+        assert status == "pay"
+
+    @patch("app.x402.access.settings")
+    def test_cidr_whitelist(self, mock_settings):
+        """CIDR range whitelisting."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = "10.0.0.0/8"
+
+        status, _ = check_access("10.50.100.200")
+        assert status == "free"
+
+        status, _ = check_access("192.168.1.1")
+        assert status == "pay"
+
+    @patch("app.x402.access.settings")
+    def test_wallet_address_parameter_accepted(self, mock_settings):
+        """Wallet address parameter is accepted (future use)."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        # Should not raise error
+        status, reason = check_access("192.168.1.1", wallet_address="0x1234")
+        assert status == "pay"
+
+
+class TestGetAccessControlStatus:
+    """Test access control status reporting."""
+
+    @patch("app.x402.access.settings")
+    def test_status_with_entries(self, mock_settings):
+        """Status includes correct counts and entries."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.100, 10.0.0.0/8"
+        mock_settings.X402_WHITELIST_IPS = "172.16.0.1"
+
+        status = get_access_control_status()
+
+        assert status["blacklist_count"] == 2
+        assert status["whitelist_count"] == 1
+        assert "192.168.1.100" in status["blacklist_entries"]
+        assert "10.0.0.0/8" in status["blacklist_entries"]
+        assert "172.16.0.1" in status["whitelist_entries"]
+
+    @patch("app.x402.access.settings")
+    def test_status_empty_lists(self, mock_settings):
+        """Status with empty lists."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = None
+
+        status = get_access_control_status()
+
+        assert status["blacklist_count"] == 0
+        assert status["whitelist_count"] == 0
+        assert status["blacklist_entries"] == []
+        assert status["whitelist_entries"] == []
+
+
+class TestEdgeCases:
+    """Test edge cases and special scenarios."""
+
+    @patch("app.x402.access.settings")
+    def test_localhost_ipv4(self, mock_settings):
+        """Localhost IPv4 can be whitelisted."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = "127.0.0.1"
+
+        status, _ = check_access("127.0.0.1")
+        assert status == "free"
+
+    @patch("app.x402.access.settings")
+    def test_localhost_ipv6(self, mock_settings):
+        """Localhost IPv6 can be whitelisted."""
+        mock_settings.X402_BLACKLIST_IPS = ""
+        mock_settings.X402_WHITELIST_IPS = "::1"
+
+        status, _ = check_access("::1")
+        assert status == "free"
+
+    @patch("app.x402.access.settings")
+    def test_duplicate_entries_handled(self, mock_settings):
+        """Duplicate entries in list are deduplicated."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.1, 192.168.1.1, 192.168.1.1"
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status = get_access_control_status()
+        assert status["blacklist_count"] == 1
+
+    @patch("app.x402.access.settings")
+    def test_trailing_comma_handled(self, mock_settings):
+        """Trailing comma is handled gracefully."""
+        mock_settings.X402_BLACKLIST_IPS = "192.168.1.1,"
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status = get_access_control_status()
+        assert status["blacklist_count"] == 1
+        assert "192.168.1.1" in status["blacklist_entries"]
+
+    @patch("app.x402.access.settings")
+    def test_leading_comma_handled(self, mock_settings):
+        """Leading comma is handled gracefully."""
+        mock_settings.X402_BLACKLIST_IPS = ",192.168.1.1"
+        mock_settings.X402_WHITELIST_IPS = ""
+
+        status = get_access_control_status()
+        assert status["blacklist_count"] == 1


### PR DESCRIPTION
## Summary

- Implement IP-based access control for x402 gateway
- Add whitelist (bypass payment) and blacklist (block access) support
- Support IPv4, IPv6, and CIDR notation
- Add comprehensive unit tests (36 tests)

## Changes

### app/x402/access.py
- `parse_ip_list()` - Parse comma-separated IPs/CIDRs from config
- `ip_matches_list()` - Check if IP matches entries (exact or CIDR)
- `is_ip_blacklisted()` - Check against X402_BLACKLIST_IPS
- `is_ip_whitelisted()` - Check against X402_WHITELIST_IPS
- `check_access()` - Main entry point returning (status, reason)
- `get_access_control_status()` - Returns current config for diagnostics

### Access States
- `"blocked"` - IP in blacklist (return 403 Forbidden)
- `"free"` - IP in whitelist (bypass x402 payment)
- `"pay"` - Normal access (require x402 payment)

### Features
- IPv4 and IPv6 address support
- CIDR notation for ranges (e.g., `10.0.0.0/8`, `192.168.0.0/24`)
- Blacklist takes precedence over whitelist
- Invalid entries logged and skipped gracefully
- Handles edge cases (trailing commas, whitespace, duplicates)

### tests/test_x402_access.py
- 36 unit tests covering all access control functionality

## Test plan

- [x] All 36 access control tests pass
- [x] All 115 x402 tests pass (preflight + pricing + middleware + access)

Closes #33