### PR TITLE
Add gateway wallet monitoring for x402 (Issue #47)

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -50,6 +50,10 @@ class Settings(BaseSettings):
     # === Base Chain Settings (for monitoring USDC receipts) ===
     BASE_RPC_URL: str = "https://sepolia.base.org"
 
+    # === Base Sepolia Gateway Wallet Monitoring ===
+    X402_BASE_ETH_WARN_THRESHOLD: float = 0.005  # Warn if ETH < threshold (~50 txs)
+    X402_BASE_ETH_CRITICAL_THRESHOLD: float = 0.001  # Block if ETH < critical (~10 txs)
+
     @field_validator("X402_BLACKLIST_IPS", "X402_WHITELIST_IPS", mode="before")
     @classmethod
     def empty_str_to_empty(cls, v: str) -> str:

--- a/app/x402/base_balance.py
+++ b/app/x402/base_balance.py
@@ -1,0 +1,189 @@
+# app/x402/base_balance.py
+"""
+Base Sepolia ETH balance monitoring for x402 gateway wallet.
+
+This module monitors the gateway wallet's ETH balance on Base Sepolia
+to ensure there's sufficient gas for the facilitator to execute USDC transfers.
+
+Balance thresholds are configured via environment variables in app/core/config.py.
+"""
+import logging
+import time
+import requests
+from typing import Dict, Any, Optional
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Conversion constant
+WEI_PER_ETH = 10 ** 18
+
+# Cache for balance checks (avoid hammering RPC endpoint)
+_balance_cache: Dict[str, Any] = {
+    "balance_wei": None,
+    "timestamp": 0,
+}
+CACHE_TTL_SECONDS = 60  # Cache balance for 60 seconds
+
+
+def wei_to_eth(wei: int) -> float:
+    """Convert wei to ETH."""
+    return wei / WEI_PER_ETH
+
+
+def _get_eth_balance_from_rpc(address: str) -> int:
+    """
+    Fetch ETH balance from Base Sepolia RPC.
+
+    Args:
+        address: Ethereum address to check
+
+    Returns:
+        Balance in wei
+
+    Raises:
+        Exception: If RPC call fails
+    """
+    response = requests.post(
+        settings.BASE_RPC_URL,
+        json={
+            "jsonrpc": "2.0",
+            "method": "eth_getBalance",
+            "params": [address, "latest"],
+            "id": 1
+        },
+        timeout=10
+    )
+    response.raise_for_status()
+
+    result = response.json()
+    if "error" in result:
+        raise Exception(f"RPC error: {result['error']}")
+
+    if "result" not in result:
+        raise Exception(f"Invalid RPC response: missing 'result' field")
+
+    # Convert hex to int
+    return int(result["result"], 16)
+
+
+def _get_cached_balance() -> Optional[int]:
+    """
+    Get cached balance if still valid.
+
+    Returns:
+        Cached balance in wei, or None if cache expired/empty
+    """
+    if _balance_cache["balance_wei"] is None:
+        return None
+
+    age = time.time() - _balance_cache["timestamp"]
+    if age > CACHE_TTL_SECONDS:
+        return None
+
+    return _balance_cache["balance_wei"]
+
+
+def _update_cache(balance_wei: int) -> None:
+    """Update the balance cache."""
+    _balance_cache["balance_wei"] = balance_wei
+    _balance_cache["timestamp"] = time.time()
+
+
+def clear_balance_cache() -> None:
+    """Clear the balance cache (useful for testing)."""
+    _balance_cache["balance_wei"] = None
+    _balance_cache["timestamp"] = 0
+
+
+def check_base_eth_balance() -> Dict[str, Any]:
+    """
+    Check Base Sepolia ETH balance against configured thresholds.
+
+    This function checks the gateway wallet's ETH balance and compares
+    it against warning and critical thresholds. Results are cached
+    for 60 seconds to avoid excessive RPC calls.
+
+    Returns:
+        Dict containing:
+        - ok: bool - whether balance is above warning threshold
+        - is_critical: bool - whether balance is below critical threshold
+        - balance_wei: int - raw balance in wei
+        - balance_eth: float - balance in ETH
+        - threshold_eth: float - warning threshold in ETH
+        - critical_eth: float - critical threshold in ETH
+        - address: str - wallet address being monitored
+        - warning: str or None - warning message if below threshold
+    """
+    address = settings.X402_PAY_TO_ADDRESS
+    warn_threshold = settings.X402_BASE_ETH_WARN_THRESHOLD
+    critical_threshold = settings.X402_BASE_ETH_CRITICAL_THRESHOLD
+
+    # If no address configured, return error state
+    if not address:
+        logger.error("X402_PAY_TO_ADDRESS not configured - cannot check balance")
+        return {
+            "ok": False,
+            "is_critical": True,
+            "balance_wei": 0,
+            "balance_eth": 0.0,
+            "threshold_eth": warn_threshold,
+            "critical_eth": critical_threshold,
+            "address": None,
+            "warning": "X402_PAY_TO_ADDRESS not configured"
+        }
+
+    try:
+        # Try to use cached balance first
+        balance_wei = _get_cached_balance()
+        if balance_wei is None:
+            balance_wei = _get_eth_balance_from_rpc(address)
+            _update_cache(balance_wei)
+            logger.debug(f"Fetched Base ETH balance: {wei_to_eth(balance_wei):.6f} ETH")
+
+        balance_eth = wei_to_eth(balance_wei)
+
+        # Determine status
+        is_critical = balance_eth < critical_threshold
+        ok = balance_eth >= warn_threshold
+
+        # Build warning message
+        warning = None
+        if is_critical:
+            warning = (
+                f"Base wallet ETH critically low ({balance_eth:.6f} ETH). "
+                f"Below critical threshold ({critical_threshold} ETH). "
+                f"Cannot process x402 payments. Top up immediately!"
+            )
+            logger.error(f"Pre-flight check: {warning}")
+        elif not ok:
+            warning = (
+                f"Base wallet ETH ({balance_eth:.6f} ETH) is below warning threshold "
+                f"({warn_threshold} ETH). Top up your Base Sepolia wallet soon."
+            )
+            logger.warning(f"Pre-flight check: {warning}")
+
+        return {
+            "ok": ok,
+            "is_critical": is_critical,
+            "balance_wei": balance_wei,
+            "balance_eth": balance_eth,
+            "threshold_eth": warn_threshold,
+            "critical_eth": critical_threshold,
+            "address": address,
+            "warning": warning
+        }
+
+    except Exception as e:
+        logger.error(f"Failed to check Base ETH balance: {e}")
+        return {
+            "ok": False,
+            "is_critical": True,  # Treat RPC errors as critical (can't verify)
+            "balance_wei": 0,
+            "balance_eth": 0.0,
+            "threshold_eth": warn_threshold,
+            "critical_eth": critical_threshold,
+            "address": address,
+            "warning": f"Failed to fetch Base ETH balance: {str(e)}"
+        }

--- a/tests/test_base_balance.py
+++ b/tests/test_base_balance.py
@@ -1,0 +1,304 @@
+# tests/test_base_balance.py
+"""
+Unit tests for Base Sepolia ETH balance monitoring.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.x402.base_balance import (
+    wei_to_eth,
+    check_base_eth_balance,
+    clear_balance_cache,
+    WEI_PER_ETH,
+    CACHE_TTL_SECONDS,
+)
+
+
+class TestConversionFunctions:
+    """Test unit conversion functions."""
+
+    def test_wei_to_eth_zero(self):
+        """Zero wei equals zero ETH."""
+        assert wei_to_eth(0) == 0.0
+
+    def test_wei_to_eth_one_eth(self):
+        """One ETH worth of wei."""
+        assert wei_to_eth(WEI_PER_ETH) == 1.0
+
+    def test_wei_to_eth_fractional(self):
+        """Fractional ETH values."""
+        assert wei_to_eth(WEI_PER_ETH // 2) == 0.5
+
+    def test_wei_to_eth_small_amount(self):
+        """Small ETH amounts (typical gas amounts)."""
+        # 0.001 ETH = 10^15 wei
+        wei = 10 ** 15
+        assert wei_to_eth(wei) == 0.001
+
+    def test_wei_to_eth_large_amount(self):
+        """Large ETH amounts."""
+        # 100 ETH
+        wei = 100 * WEI_PER_ETH
+        assert wei_to_eth(wei) == 100.0
+
+
+class TestCheckBaseEthBalance:
+    """Test Base ETH balance checks."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_balance_cache()
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_above_threshold(self, mock_settings, mock_get_balance):
+        """Balance above warning threshold returns ok=True."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)  # 0.01 ETH
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is True
+        assert result["is_critical"] is False
+        assert result["balance_eth"] == 0.01
+        assert result["threshold_eth"] == 0.005
+        assert result["warning"] is None
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_below_warning_threshold(self, mock_settings, mock_get_balance):
+        """Balance below warning threshold returns ok=False with warning."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.003 * WEI_PER_ETH)  # 0.003 ETH
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False
+        assert result["is_critical"] is False
+        assert result["balance_eth"] == 0.003
+        assert "below warning threshold" in result["warning"]
+        assert "Top up" in result["warning"]
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_below_critical_threshold(self, mock_settings, mock_get_balance):
+        """Balance below critical threshold returns is_critical=True."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.0005 * WEI_PER_ETH)  # 0.0005 ETH
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False
+        assert result["is_critical"] is True
+        assert result["balance_eth"] == 0.0005
+        assert "critically low" in result["warning"]
+        assert "immediately" in result["warning"]
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_at_warning_threshold(self, mock_settings, mock_get_balance):
+        """Balance exactly at warning threshold returns ok=True."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.005 * WEI_PER_ETH)  # Exactly at threshold
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is True
+        assert result["is_critical"] is False
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_at_critical_threshold(self, mock_settings, mock_get_balance):
+        """Balance exactly at critical threshold returns is_critical=False."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.001 * WEI_PER_ETH)  # Exactly at critical
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False  # Below warning
+        assert result["is_critical"] is False  # But not below critical
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_rpc_error_returns_critical(self, mock_settings, mock_get_balance):
+        """RPC error returns is_critical=True (can't verify balance)."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.side_effect = Exception("Connection refused")
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False
+        assert result["is_critical"] is True
+        assert result["balance_eth"] == 0.0
+        assert "Failed to fetch" in result["warning"]
+        assert "Connection refused" in result["warning"]
+
+    @patch("app.x402.base_balance.settings")
+    def test_no_address_configured(self, mock_settings):
+        """Missing PAY_TO_ADDRESS returns error state."""
+        mock_settings.X402_PAY_TO_ADDRESS = None
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False
+        assert result["is_critical"] is True
+        assert result["address"] is None
+        assert "not configured" in result["warning"]
+
+    @patch("app.x402.base_balance.settings")
+    def test_empty_address_configured(self, mock_settings):
+        """Empty PAY_TO_ADDRESS returns error state."""
+        mock_settings.X402_PAY_TO_ADDRESS = ""
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+
+        result = check_base_eth_balance()
+
+        assert result["ok"] is False
+        assert result["is_critical"] is True
+
+
+class TestCaching:
+    """Test balance caching behavior."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_balance_cache()
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_cache_is_used(self, mock_settings, mock_get_balance):
+        """Second call uses cached value."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
+
+        # First call - should fetch from RPC
+        result1 = check_base_eth_balance()
+        # Second call - should use cache
+        result2 = check_base_eth_balance()
+
+        # RPC should only be called once
+        assert mock_get_balance.call_count == 1
+        assert result1["balance_eth"] == result2["balance_eth"]
+
+    @patch("app.x402.base_balance.time")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_cache_expires(self, mock_settings, mock_get_balance, mock_time):
+        """Cache expires after TTL."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
+
+        # First call at time 0
+        mock_time.time.return_value = 0
+        check_base_eth_balance()
+
+        # Second call at time 30 (within TTL)
+        mock_time.time.return_value = 30
+        check_base_eth_balance()
+
+        # Should still be just 1 RPC call
+        assert mock_get_balance.call_count == 1
+
+        # Third call at time 61 (after TTL)
+        mock_time.time.return_value = CACHE_TTL_SECONDS + 1
+        check_base_eth_balance()
+
+        # Should now be 2 RPC calls
+        assert mock_get_balance.call_count == 2
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_clear_cache(self, mock_settings, mock_get_balance):
+        """clear_balance_cache() forces new RPC call."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
+
+        # First call
+        check_base_eth_balance()
+        assert mock_get_balance.call_count == 1
+
+        # Clear cache
+        clear_balance_cache()
+
+        # Second call - should fetch again
+        check_base_eth_balance()
+        assert mock_get_balance.call_count == 2
+
+
+class TestResponseStructure:
+    """Test the structure of balance check responses."""
+
+    def setup_method(self):
+        """Clear cache before each test."""
+        clear_balance_cache()
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_response_contains_all_fields(self, mock_settings, mock_get_balance):
+        """Response contains all expected fields."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
+
+        result = check_base_eth_balance()
+
+        # Check all required fields
+        assert "ok" in result
+        assert "is_critical" in result
+        assert "balance_wei" in result
+        assert "balance_eth" in result
+        assert "threshold_eth" in result
+        assert "critical_eth" in result
+        assert "address" in result
+        assert "warning" in result
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_response_includes_address(self, mock_settings, mock_get_balance):
+        """Response includes the monitored address."""
+        address = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12"
+        mock_settings.X402_PAY_TO_ADDRESS = address
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
+
+        result = check_base_eth_balance()
+
+        assert result["address"] == address
+
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance.settings")
+    def test_balance_wei_is_integer(self, mock_settings, mock_get_balance):
+        """balance_wei is returned as integer."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
+        mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
+        mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
+        expected_wei = int(0.01 * WEI_PER_ETH)
+        mock_get_balance.return_value = expected_wei
+
+        result = check_base_eth_balance()
+
+        assert isinstance(result["balance_wei"], int)
+        assert result["balance_wei"] == expected_wei


### PR DESCRIPTION
## Summary

- Add Base Sepolia ETH balance monitoring for the gateway wallet
- Health endpoint now shows x402 wallet status when enabled
- Middleware blocks requests when ETH balance is critically low

## Changes

### New Module: `app/x402/base_balance.py`
- `wei_to_eth()` conversion function
- `check_base_eth_balance()` with 60-second caching
- Warning (0.005 ETH) and critical (0.001 ETH) threshold checks
- Graceful RPC error handling

### Config Settings
- `X402_BASE_ETH_WARN_THRESHOLD` (default: 0.005 ETH) - ~50 transactions
- `X402_BASE_ETH_CRITICAL_THRESHOLD` (default: 0.001 ETH) - ~10 transactions

### Health Endpoint Enhancement
- Returns `status: "ok" | "degraded" | "critical"`
- Includes Base wallet and Gnosis wallet balances when x402 enabled
- Returns 503 when balance is critically low

### Middleware Enhancement
- Blocks protected endpoints with 503 when ETH balance is critical
- Allows requests (returns 402) when balance is low but not critical

## Test Plan

- [x] 19 unit tests for `base_balance.py` (conversion, thresholds, caching, RPC errors)
- [x] 7 integration tests for health endpoint and middleware
- [x] All 222 x402 tests pass

Closes #47