### PR TITLE
Add x402 startup validation to prevent misconfiguration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,50 @@
+# === Swarm Bee Node ===
 SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
+
+# === Server ===
+# HOST=127.0.0.1
+# PORT=8000
+# RELOAD=true
+
+# === API Authentication (optional) ===
 # API_KEY=
 # API_KEY_NAME=X-API-Key
+
+# === x402 Payment Gateway (disabled by default) ===
+# When X402_ENABLED=true, the following settings are validated at startup.
+# The app will fail to start if required settings are missing or invalid.
+
+X402_ENABLED=false
+
+# Required when X402_ENABLED=true:
+# X402_PAY_TO_ADDRESS=0x...          # Your Ethereum address to receive USDC payments (on Base)
+# X402_NETWORK=base-sepolia          # Network: "base" (mainnet) or "base-sepolia" (testnet)
+# X402_FACILITATOR_URL=https://x402.org/facilitator  # x402 facilitator URL
+
+# === x402 Pricing ===
+# X402_BZZ_USD_RATE=0.50             # Manual BZZ/USD exchange rate
+# X402_MARKUP_PERCENT=50             # Markup percentage on top of BZZ cost
+# X402_MIN_PRICE_USD=0.01            # Minimum charge per request in USD
+
+# === x402 Rate Limiting ===
+# X402_RATE_LIMIT_PER_IP=10          # Max paid requests per minute per IP
+
+# === x402 Free Tier (optional) ===
+# X402_FREE_TIER_ENABLED=false       # Enable free tier for small uploads
+# X402_FREE_TIER_RATE_LIMIT=5        # Max free requests per minute per IP
+
+# === x402 Balance Thresholds (Gnosis) ===
+# X402_XBZZ_WARN_THRESHOLD=10        # Warn if xBZZ balance below this
+# X402_XDAI_WARN_THRESHOLD=0.5       # Warn if xDAI balance below this
+# X402_CHEQUEBOOK_WARN_THRESHOLD=5   # Warn if chequebook balance below this
+
+# === x402 Balance Thresholds (Base) ===
+# X402_BASE_ETH_WARN_THRESHOLD=0.005     # Warn if Base ETH below this
+# X402_BASE_ETH_CRITICAL_THRESHOLD=0.001 # Critical if Base ETH below this
+
+# === x402 Access Control ===
+# X402_WHITELIST_IPS=                # Comma-separated IPs that bypass x402 (free access)
+# X402_BLACKLIST_IPS=                # Comma-separated IPs that are blocked
+
+# === x402 Audit Logging ===
+# X402_AUDIT_LOG_PATH=logs/x402_audit.jsonl

--- a/app/main.py
+++ b/app/main.py
@@ -16,8 +16,10 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json" # Standard location for OpenAPI spec
 )
 
-# Add x402 payment middleware if enabled
+# Validate and add x402 payment middleware if enabled
 if settings.X402_ENABLED:
+    from app.x402.validation import check_x402_startup
+    check_x402_startup()  # Will raise X402ConfigurationError if invalid
     from app.x402.middleware import X402Middleware
     app.add_middleware(X402Middleware)
     logger.info("x402 middleware enabled")

--- a/app/x402/validation.py
+++ b/app/x402/validation.py
@@ -1,0 +1,124 @@
+# app/x402/validation.py
+"""
+Startup validation for x402 configuration.
+
+When X402_ENABLED=true, validates that all required configuration is present
+and correctly formatted before the application starts accepting requests.
+"""
+import re
+import logging
+from typing import List, Tuple
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Ethereum address pattern (0x followed by 40 hex characters)
+ETH_ADDRESS_PATTERN = re.compile(r"^0x[a-fA-F0-9]{40}$")
+
+# Valid x402 networks
+VALID_NETWORKS = ["base", "base-sepolia"]
+
+
+class X402ConfigurationError(Exception):
+    """Raised when x402 configuration is invalid."""
+    pass
+
+
+def validate_eth_address(address: str, field_name: str) -> Tuple[bool, str]:
+    """
+    Validate an Ethereum address format.
+
+    Returns:
+        Tuple of (is_valid, error_message)
+    """
+    if not address:
+        return False, f"{field_name} is required but not set"
+
+    if not ETH_ADDRESS_PATTERN.match(address):
+        return False, f"{field_name} is not a valid Ethereum address: {address}"
+
+    # Check for obviously invalid addresses
+    if address == "0x0000000000000000000000000000000000000000":
+        return False, f"{field_name} is set to the zero address"
+
+    return True, ""
+
+
+def validate_x402_config() -> List[str]:
+    """
+    Validate x402 configuration when X402_ENABLED=true.
+
+    Returns:
+        List of error messages (empty if all valid)
+    """
+    errors = []
+
+    # Validate X402_PAY_TO_ADDRESS
+    is_valid, error = validate_eth_address(
+        settings.X402_PAY_TO_ADDRESS or "",
+        "X402_PAY_TO_ADDRESS"
+    )
+    if not is_valid:
+        errors.append(error)
+
+    # Validate X402_NETWORK
+    if settings.X402_NETWORK not in VALID_NETWORKS:
+        errors.append(
+            f"X402_NETWORK must be one of {VALID_NETWORKS}, got: {settings.X402_NETWORK}"
+        )
+
+    # Validate X402_FACILITATOR_URL
+    if not settings.X402_FACILITATOR_URL:
+        errors.append("X402_FACILITATOR_URL is required but not set")
+    elif not settings.X402_FACILITATOR_URL.startswith(("http://", "https://")):
+        errors.append(
+            f"X402_FACILITATOR_URL must be a valid URL: {settings.X402_FACILITATOR_URL}"
+        )
+
+    # Validate pricing settings
+    if settings.X402_MIN_PRICE_USD <= 0:
+        errors.append("X402_MIN_PRICE_USD must be positive")
+
+    if settings.X402_BZZ_USD_RATE <= 0:
+        errors.append("X402_BZZ_USD_RATE must be positive")
+
+    # Validate rate limits
+    if settings.X402_RATE_LIMIT_PER_IP <= 0:
+        errors.append("X402_RATE_LIMIT_PER_IP must be positive")
+
+    if settings.X402_FREE_TIER_ENABLED and settings.X402_FREE_TIER_RATE_LIMIT <= 0:
+        errors.append("X402_FREE_TIER_RATE_LIMIT must be positive when free tier is enabled")
+
+    return errors
+
+
+def check_x402_startup() -> None:
+    """
+    Check x402 configuration at startup.
+
+    If X402_ENABLED=true and configuration is invalid, raises X402ConfigurationError.
+    If X402_ENABLED=false, logs info and returns.
+
+    Raises:
+        X402ConfigurationError: If x402 is enabled but configuration is invalid
+    """
+    if not settings.X402_ENABLED:
+        logger.info("x402 is disabled (X402_ENABLED=false)")
+        return
+
+    logger.info("x402 is enabled - validating configuration...")
+
+    errors = validate_x402_config()
+
+    if errors:
+        error_msg = "x402 configuration errors:\n" + "\n".join(f"  - {e}" for e in errors)
+        logger.error(error_msg)
+        raise X402ConfigurationError(error_msg)
+
+    # Log successful configuration
+    logger.info(f"x402 configuration valid:")
+    logger.info(f"  - Network: {settings.X402_NETWORK}")
+    logger.info(f"  - Pay-to address: {settings.X402_PAY_TO_ADDRESS}")
+    logger.info(f"  - Facilitator: {settings.X402_FACILITATOR_URL}")
+    logger.info(f"  - Free tier: {'enabled' if settings.X402_FREE_TIER_ENABLED else 'disabled'}")

--- a/tests/test_x402_validation.py
+++ b/tests/test_x402_validation.py
@@ -1,0 +1,384 @@
+# tests/test_x402_validation.py
+"""
+Unit tests for x402 startup validation.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.x402.validation import (
+    validate_eth_address,
+    validate_x402_config,
+    check_x402_startup,
+    X402ConfigurationError,
+    ETH_ADDRESS_PATTERN,
+    VALID_NETWORKS,
+)
+
+
+class TestValidateEthAddress:
+    """Test Ethereum address validation."""
+
+    def test_valid_address_lowercase(self):
+        """Valid lowercase address passes."""
+        is_valid, error = validate_eth_address(
+            "0x1234567890abcdef1234567890abcdef12345678",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is True
+        assert error == ""
+
+    def test_valid_address_uppercase(self):
+        """Valid uppercase address passes."""
+        is_valid, error = validate_eth_address(
+            "0xABCDEF1234567890ABCDEF1234567890ABCDEF12",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is True
+        assert error == ""
+
+    def test_valid_address_mixed_case(self):
+        """Valid mixed-case address passes (checksum format)."""
+        is_valid, error = validate_eth_address(
+            "0xAbCdEf1234567890abcdef1234567890AbCdEf12",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is True
+        assert error == ""
+
+    def test_empty_address_fails(self):
+        """Empty address fails validation."""
+        is_valid, error = validate_eth_address("", "TEST_ADDRESS")
+        assert is_valid is False
+        assert "required but not set" in error
+
+    def test_none_address_fails(self):
+        """None address fails validation."""
+        is_valid, error = validate_eth_address(None, "TEST_ADDRESS")
+        assert is_valid is False
+        assert "required but not set" in error
+
+    def test_missing_0x_prefix_fails(self):
+        """Address without 0x prefix fails."""
+        is_valid, error = validate_eth_address(
+            "1234567890abcdef1234567890abcdef12345678",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is False
+        assert "not a valid Ethereum address" in error
+
+    def test_too_short_fails(self):
+        """Address too short fails."""
+        is_valid, error = validate_eth_address(
+            "0x12345678",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is False
+        assert "not a valid Ethereum address" in error
+
+    def test_too_long_fails(self):
+        """Address too long fails."""
+        is_valid, error = validate_eth_address(
+            "0x1234567890abcdef1234567890abcdef1234567890",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is False
+        assert "not a valid Ethereum address" in error
+
+    def test_invalid_characters_fails(self):
+        """Address with invalid characters fails."""
+        is_valid, error = validate_eth_address(
+            "0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is False
+        assert "not a valid Ethereum address" in error
+
+    def test_zero_address_fails(self):
+        """Zero address (0x0...0) fails validation."""
+        is_valid, error = validate_eth_address(
+            "0x0000000000000000000000000000000000000000",
+            "TEST_ADDRESS"
+        )
+        assert is_valid is False
+        assert "zero address" in error
+
+    def test_field_name_in_error(self):
+        """Field name is included in error message."""
+        is_valid, error = validate_eth_address("", "MY_CUSTOM_FIELD")
+        assert is_valid is False
+        assert "MY_CUSTOM_FIELD" in error
+
+
+class TestValidateX402Config:
+    """Test x402 configuration validation."""
+
+    @patch("app.x402.validation.settings")
+    def test_valid_config_returns_no_errors(self, mock_settings):
+        """Valid configuration returns empty error list."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert errors == []
+
+    @patch("app.x402.validation.settings")
+    def test_missing_pay_to_address(self, mock_settings):
+        """Missing PAY_TO_ADDRESS is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = None
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_PAY_TO_ADDRESS" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_invalid_network(self, mock_settings):
+        """Invalid network is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "invalid-network"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_NETWORK" in errors[0]
+        assert "invalid-network" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_missing_facilitator_url(self, mock_settings):
+        """Missing facilitator URL is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = ""
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_FACILITATOR_URL" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_invalid_facilitator_url(self, mock_settings):
+        """Invalid facilitator URL (not http/https) is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "ftp://invalid.com"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_FACILITATOR_URL" in errors[0]
+        assert "valid URL" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_zero_min_price(self, mock_settings):
+        """Zero min price is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_MIN_PRICE_USD" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_negative_bzz_rate(self, mock_settings):
+        """Negative BZZ rate is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = -1
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_BZZ_USD_RATE" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_zero_rate_limit(self, mock_settings):
+        """Zero rate limit is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 0
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_RATE_LIMIT_PER_IP" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_free_tier_enabled_with_zero_limit(self, mock_settings):
+        """Free tier enabled with zero rate limit is caught."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = True
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 0
+
+        errors = validate_x402_config()
+        assert len(errors) == 1
+        assert "X402_FREE_TIER_RATE_LIMIT" in errors[0]
+
+    @patch("app.x402.validation.settings")
+    def test_free_tier_disabled_zero_limit_ok(self, mock_settings):
+        """Free tier disabled with zero rate limit is OK."""
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 0
+
+        errors = validate_x402_config()
+        assert errors == []
+
+    @patch("app.x402.validation.settings")
+    def test_multiple_errors_collected(self, mock_settings):
+        """Multiple config errors are all collected."""
+        mock_settings.X402_PAY_TO_ADDRESS = None  # Error 1
+        mock_settings.X402_NETWORK = "invalid"    # Error 2
+        mock_settings.X402_FACILITATOR_URL = ""   # Error 3
+        mock_settings.X402_MIN_PRICE_USD = 0      # Error 4
+        mock_settings.X402_BZZ_USD_RATE = 0       # Error 5
+        mock_settings.X402_RATE_LIMIT_PER_IP = 0  # Error 6
+        mock_settings.X402_FREE_TIER_ENABLED = True
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 0  # Error 7
+
+        errors = validate_x402_config()
+        assert len(errors) == 7
+
+
+class TestCheckX402Startup:
+    """Test startup validation function."""
+
+    @patch("app.x402.validation.settings")
+    def test_x402_disabled_returns_immediately(self, mock_settings):
+        """When X402_ENABLED=false, validation returns without checking."""
+        mock_settings.X402_ENABLED = False
+        # Don't set any other config - should not matter
+
+        # Should not raise
+        check_x402_startup()
+
+    @patch("app.x402.validation.settings")
+    def test_x402_enabled_valid_config_succeeds(self, mock_settings):
+        """When X402_ENABLED=true with valid config, succeeds."""
+        mock_settings.X402_ENABLED = True
+        mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678"
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        # Should not raise
+        check_x402_startup()
+
+    @patch("app.x402.validation.settings")
+    def test_x402_enabled_invalid_config_raises(self, mock_settings):
+        """When X402_ENABLED=true with invalid config, raises X402ConfigurationError."""
+        mock_settings.X402_ENABLED = True
+        mock_settings.X402_PAY_TO_ADDRESS = None  # Invalid
+        mock_settings.X402_NETWORK = "base-sepolia"
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        with pytest.raises(X402ConfigurationError) as exc_info:
+            check_x402_startup()
+
+        assert "X402_PAY_TO_ADDRESS" in str(exc_info.value)
+
+    @patch("app.x402.validation.settings")
+    def test_x402_enabled_multiple_errors_in_exception(self, mock_settings):
+        """Multiple config errors are all included in exception message."""
+        mock_settings.X402_ENABLED = True
+        mock_settings.X402_PAY_TO_ADDRESS = None  # Error 1
+        mock_settings.X402_NETWORK = "invalid"    # Error 2
+        mock_settings.X402_FACILITATOR_URL = "https://x402.org/facilitator"
+        mock_settings.X402_MIN_PRICE_USD = 0.01
+        mock_settings.X402_BZZ_USD_RATE = 0.50
+        mock_settings.X402_RATE_LIMIT_PER_IP = 10
+        mock_settings.X402_FREE_TIER_ENABLED = False
+        mock_settings.X402_FREE_TIER_RATE_LIMIT = 5
+
+        with pytest.raises(X402ConfigurationError) as exc_info:
+            check_x402_startup()
+
+        error_msg = str(exc_info.value)
+        assert "X402_PAY_TO_ADDRESS" in error_msg
+        assert "X402_NETWORK" in error_msg
+
+
+class TestValidNetworks:
+    """Test network validation constants."""
+
+    def test_base_sepolia_is_valid(self):
+        """base-sepolia is a valid network."""
+        assert "base-sepolia" in VALID_NETWORKS
+
+    def test_base_is_valid(self):
+        """base (mainnet) is a valid network."""
+        assert "base" in VALID_NETWORKS
+
+
+class TestEthAddressPattern:
+    """Test the ETH address regex pattern."""
+
+    def test_pattern_matches_valid_address(self):
+        """Pattern matches valid 42-char address."""
+        assert ETH_ADDRESS_PATTERN.match("0x1234567890abcdef1234567890abcdef12345678")
+
+    def test_pattern_rejects_no_prefix(self):
+        """Pattern rejects address without 0x."""
+        assert not ETH_ADDRESS_PATTERN.match("1234567890abcdef1234567890abcdef12345678")
+
+    def test_pattern_rejects_wrong_length(self):
+        """Pattern rejects wrong length."""
+        assert not ETH_ADDRESS_PATTERN.match("0x123456")
+        assert not ETH_ADDRESS_PATTERN.match("0x1234567890abcdef1234567890abcdef1234567890")


### PR DESCRIPTION
## Summary

- Adds startup validation when `X402_ENABLED=true` to fail fast on misconfiguration
- Validates Ethereum address format for `X402_PAY_TO_ADDRESS`
- Validates network is either `base` or `base-sepolia`
- Validates facilitator URL is a valid HTTP(S) URL
- Validates pricing/rate limit values are positive
- Updates `.env.example` with comprehensive x402 configuration documentation

## Problem

When deploying with `X402_ENABLED=true` but missing/invalid wallet configuration, the gateway would start successfully but fail at runtime when processing payments. This made it difficult to diagnose configuration issues.

## Solution

Added `app/x402/validation.py` with:
- `validate_eth_address()` - validates Ethereum address format
- `validate_x402_config()` - validates all x402 configuration
- `check_x402_startup()` - called on app startup, raises `X402ConfigurationError` if invalid

The app now fails to start with clear error messages if x402 is enabled but configuration is invalid.

## Test plan

- [x] Added 31 unit tests in `tests/test_x402_validation.py`
- [x] All 228 x402-related tests pass
- [x] App starts successfully with valid x402 config
- [x] App fails with clear error when x402 enabled with invalid config