### PR TITLE
Add x402 environment configuration for dev deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
   build:
     name: build
     runs-on: [self-hosted, pljudfbee1]
+    # Use staging environment for dev branch (gets variables from GitHub)
+    environment: ${{ github.ref == 'refs/heads/dev' && 'staging' || '' }}
 
     steps:
       - name: checkout
@@ -31,6 +33,17 @@ jobs:
 
       - name: build docker image
         run: docker build --build-arg VERSION=${{ steps.version.outputs.version }} -t swarm_connect:$GITHUB_REF_NAME .
+
+      - name: write env file for dev
+        if: github.ref == 'refs/heads/dev'
+        run: |
+          cat > /opt/swarm_connect_dev.env << 'EOF'
+          X402_ENABLED=${{ vars.X402_ENABLED || 'false' }}
+          X402_PAY_TO_ADDRESS=${{ vars.X402_PAY_TO_ADDRESS || '' }}
+          X402_NETWORK=${{ vars.X402_NETWORK || 'base-sepolia' }}
+          X402_FACILITATOR_URL=${{ vars.X402_FACILITATOR_URL || 'https://x402.org/facilitator' }}
+          X402_FREE_TIER_ENABLED=${{ vars.X402_FREE_TIER_ENABLED || 'true' }}
+          EOF
 
       - name: deploy
         run: >

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     image: swarm_connect:dev
     ports:
       - "8900:8000"
+    env_file:
+      - /opt/swarm_connect_dev.env
     environment:
       - SWARM_BEE_API_URL=http://192.168.45.30:1633
     restart: unless-stopped


### PR DESCRIPTION
## Summary
Enables x402 configuration for dev branch deployments via GitHub environment variables.

- Use GitHub `staging` environment for dev branch deployments
- Write x402 config from GitHub Variables to `/opt/swarm_connect_dev.env` 
- Configure dev container to load env file for x402 settings

Closes #53

## Variables to configure in staging environment

After merging, set these variables in the `staging` environment:
```bash
gh variable set X402_ENABLED --body "true" --env staging --repo datafund/swarm_connect
gh variable set X402_PAY_TO_ADDRESS --body "<wallet>" --env staging --repo datafund/swarm_connect
gh variable set X402_NETWORK --body "base-sepolia" --env staging --repo datafund/swarm_connect
gh variable set X402_FACILITATOR_URL --body "https://x402.org/facilitator" --env staging --repo datafund/swarm_connect
gh variable set X402_FREE_TIER_ENABLED --body "true" --env staging --repo datafund/swarm_connect
```

## Test plan
- [x] Merge to dev branch
- [x] Set staging environment variables
- [x] Verify deployment creates env file
- [ ] Verify dev gateway starts with x402 enabled
- [x] Test protected endpoint returns 402 with payment requirements