### PR TITLE
Upgrade Docker to Python 3.10 for x402 SDK compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use an official Python runtime as a parent image
-FROM python:3.9-slim
+# Python 3.10+ required for x402 SDK
+FROM python:3.10-slim
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
## Summary

Upgrade Dockerfile from Python 3.9 to Python 3.10 to enable x402 SDK installation.

Closes #55

## Problem

The `x402` Python SDK requires Python 3.10+. The dev deployment was failing with:
```
ERROR: Could not find a version that satisfies the requirement x402>=0.1.0
```

## Solution

Change `FROM python:3.9-slim` to `FROM python:3.10-slim`.

## Note

PR #28 previously fixed Python 3.9 compatibility for **type hint syntax** (`Optional[int]` vs `int | None`). That was about our code being compatible with Python 3.9.

This change is different - it's about the `x402` SDK **requiring** Python 3.10+. There's no workaround if we want to use x402.

## Test plan

- [ ] Merge and verify CI deployment succeeds
- [ ] Verify dev gateway comes up with x402 enabled