### PR TITLE
Fix x402 payment response: fail on settlement error, add payment mode headers

### DIFF
--- a/app/x402/middleware.py
+++ b/app/x402/middleware.py
@@ -431,7 +431,8 @@ class X402Middleware(BaseHTTPMiddleware):
                     payment_requirements=payment_requirements
                 )
 
-                logger.info(f"x402: Payment settled successfully, tx_hash={getattr(settle_response, 'transaction_hash', 'unknown')}")
+                tx_hash = getattr(settle_response, 'transaction_hash', 'unknown')
+                logger.info(f"x402: Payment settled successfully, tx_hash={tx_hash}")
 
                 # Add settlement response header
                 encoded_response = encode_payment_response(settle_response)
@@ -449,23 +450,25 @@ class X402Middleware(BaseHTTPMiddleware):
                     media_type=response.media_type
                 )
                 new_response.headers[X_PAYMENT_RESPONSE_HEADER] = encoded_response
+                new_response.headers["X-Payment-Mode"] = "paid"
+                new_response.headers["X-Payment-Transaction"] = tx_hash
 
                 return new_response
 
             except Exception as e:
                 logger.error(f"x402: Payment settlement failed: {type(e).__name__}: {e}", exc_info=True)
-                # Request already succeeded, so return success but log the error
-                # In production, you might want to handle this differently
-                # Read response body before returning
-                body = b""
-                async for chunk in response.body_iterator:
-                    body += chunk
-
-                return Response(
-                    content=body,
-                    status_code=response.status_code,
-                    headers=dict(response.headers),
-                    media_type=response.media_type
+                # Settlement failed - return error, don't silently succeed
+                # This is critical: if settlement fails, the payment wasn't collected
+                # The client should know and can retry or use free tier explicitly
+                return JSONResponse(
+                    status_code=500,
+                    content={
+                        "error": "Payment settlement failed",
+                        "detail": f"Your request was processed but payment settlement failed: {str(e)}",
+                        "x402_status": "settlement_failed",
+                        "message": "Please retry with a new payment or use X-Payment-Mode: free for free tier access"
+                    },
+                    headers={"X-Payment-Mode": "failed"}
                 )
 
         return response


### PR DESCRIPTION
## Summary

Addresses feedback from CLI developer regarding x402 payment handling:

- **Settlement failure now returns error**: When payment settlement fails, gateway returns 500 instead of silently succeeding
- **Payment mode headers added**: Successful paid responses include `X-Payment-Mode: paid` and `X-Payment-Transaction: <hash>` headers
- **Failed payment indication**: Settlement failures include `X-Payment-Mode: failed` header

## Changes

- Return 500 error with actionable message when settlement fails (previously returned success)
- Add `X-Payment-Mode: paid` header to successful paid tier responses
- Add `X-Payment-Transaction` header with transaction hash for paid responses
- Add `X-Payment-Mode: failed` header when settlement fails

## Response Headers by Mode

| Mode | Headers |
|------|---------|
| Free tier | `X-Payment-Mode: free-tier` + rate limit headers |
| Paid (success) | `X-Payment-Mode: paid` + `X-Payment-Transaction: <hash>` + `X-PAYMENT-RESPONSE` |
| Paid (settlement failed) | `X-Payment-Mode: failed` + 500 error body |

## Testing

- All 42 x402 middleware unit tests pass
- Manual testing recommended on dev gateway

Closes #58