### PR TITLE
Add API integration for notary signing (#72)

### DIFF
--- a/app/api/endpoints/data.py
+++ b/app/api/endpoints/data.py
@@ -27,6 +27,13 @@ from app.services.swarm_api import (
     StampValidationError,
     REDUNDANCY_LEVELS
 )
+from app.core.config import settings
+from app.services.provenance import (
+    get_provenance_service,
+    DocumentValidationError,
+    NotaryNotEnabledError
+)
+from app.services.signing import NotConfiguredError
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -98,6 +105,7 @@ async def upload_data(
     deferred: bool = False,
     include_timing: bool = False,
     redundancy: Optional[int] = None,
+    sign: Optional[str] = None,
     file: UploadFile = File(...)
 ):
     """
@@ -111,6 +119,7 @@ async def upload_data(
     - Optional `deferred` parameter (defaults to false)
     - Optional `include_timing` parameter (defaults to false)
     - Optional `redundancy` parameter (0-4, defaults to 2=strong)
+    - Optional `sign` parameter ("notary" to add gateway notary signature)
 
     **Stamp Validation** (opt-in with `validate_stamp=true`):
     When enabled, validates the stamp before upload:
@@ -142,6 +151,14 @@ async def upload_data(
     - `bee_upload_ms`: Time uploading to Bee node
     - `total_ms`: Total request processing time
 
+    **Notary Signing** (opt-in with `sign=notary`):
+    When enabled, the gateway adds a cryptographic signature to prove data existed at upload time.
+    - Requires `NOTARY_ENABLED=true` and `NOTARY_PRIVATE_KEY` to be configured
+    - Document must be JSON with a `data` field: `{"data": {...}, "signatures": [...]}`
+    - Gateway adds a notary signature to the signatures array
+    - Check `/api/v1/notary/info` for notary availability and public address
+    - Returns 400 if document format is invalid or notary is not configured
+
     **Usage Examples**:
     ```bash
     # Upload JSON file (direct mode, default)
@@ -163,6 +180,10 @@ async def upload_data(
     # Upload binary file
     curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=ABC123&content_type=image/png" \\
          -F "file=@image.png"
+
+    # Upload with notary signing (requires NOTARY_ENABLED=true)
+    curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=ABC123&sign=notary" \\
+         -F "file=@provenance-doc.json"
     ```
 
     **Supported Content Types**: JSON, text, images, PDFs, or any binary data.
@@ -225,6 +246,51 @@ async def upload_data(
         file_start = time.perf_counter()
         data_bytes = await file.read()
         file_read_ms = (time.perf_counter() - file_start) * 1000
+
+        # Optional notary signing
+        if sign == "notary":
+            try:
+                provenance_service = get_provenance_service()
+                signed_doc = provenance_service.sign_document(data_bytes)
+                data_bytes = signed_doc.raw_json.encode('utf-8')
+                content_type = "application/json"  # Signed documents are always JSON
+                logger.info(f"Document signed by notary, signatures count: {len(signed_doc.signatures)}")
+            except NotaryNotEnabledError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "code": "NOTARY_NOT_ENABLED",
+                        "message": str(e),
+                        "suggestion": "Set NOTARY_ENABLED=true to enable notary signing"
+                    }
+                )
+            except NotConfiguredError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "code": "NOTARY_NOT_CONFIGURED",
+                        "message": str(e),
+                        "suggestion": "Set NOTARY_PRIVATE_KEY to configure the notary signing key"
+                    }
+                )
+            except DocumentValidationError as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail={
+                        "code": "INVALID_DOCUMENT_FORMAT",
+                        "message": str(e),
+                        "suggestion": "Document must be JSON with a 'data' field: {\"data\": {...}, \"signatures\": [...]}"
+                    }
+                )
+        elif sign is not None:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "code": "INVALID_SIGN_OPTION",
+                    "message": f"Invalid sign option: {sign}",
+                    "suggestion": "Use sign=notary for gateway notary signing"
+                }
+            )
 
         # Upload to Swarm
         bee_start = time.perf_counter()

--- a/app/api/endpoints/notary.py
+++ b/app/api/endpoints/notary.py
@@ -1,0 +1,116 @@
+# app/api/endpoints/notary.py
+"""
+API endpoints for notary/provenance signing functionality.
+"""
+import logging
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+from app.core.config import settings
+from app.services.provenance import get_provenance_service
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+
+class NotaryInfoResponse(BaseModel):
+    """Response model for notary info endpoint."""
+    enabled: bool
+    available: bool
+    address: Optional[str] = None
+    message: str
+
+
+class NotaryStatusResponse(BaseModel):
+    """Response model for notary status check."""
+    enabled: bool
+    available: bool
+    address: Optional[str] = None
+
+
+@router.get("/info", response_model=NotaryInfoResponse)
+async def get_notary_info():
+    """
+    Get information about the gateway's notary signing service.
+
+    **Response when enabled and configured:**
+    ```json
+    {
+        "enabled": true,
+        "available": true,
+        "address": "0x1234...abcd",
+        "message": "Notary signing is available. Use sign=notary on upload."
+    }
+    ```
+
+    **Response when enabled but not configured:**
+    ```json
+    {
+        "enabled": true,
+        "available": false,
+        "address": null,
+        "message": "Notary is enabled but not configured (missing NOTARY_PRIVATE_KEY)."
+    }
+    ```
+
+    **Response when disabled:**
+    ```json
+    {
+        "enabled": false,
+        "available": false,
+        "address": null,
+        "message": "Notary signing is not enabled on this gateway."
+    }
+    ```
+
+    **Use case:**
+    Clients should call this endpoint to:
+    1. Check if notary signing is available before uploading with `sign=notary`
+    2. Get the notary's public address for verification purposes
+
+    **Verification:**
+    The `address` field contains the Ethereum address derived from the notary's
+    private key. Clients can use this address to verify signatures on downloaded
+    documents using standard EIP-191 verification.
+    """
+    provenance_service = get_provenance_service()
+
+    if not settings.NOTARY_ENABLED:
+        return NotaryInfoResponse(
+            enabled=False,
+            available=False,
+            address=None,
+            message="Notary signing is not enabled on this gateway."
+        )
+
+    if not provenance_service.is_available:
+        return NotaryInfoResponse(
+            enabled=True,
+            available=False,
+            address=None,
+            message="Notary is enabled but not configured (missing NOTARY_PRIVATE_KEY)."
+        )
+
+    return NotaryInfoResponse(
+        enabled=True,
+        available=True,
+        address=provenance_service.notary_address,
+        message="Notary signing is available. Use sign=notary on upload."
+    )
+
+
+@router.get("/status", response_model=NotaryStatusResponse)
+async def get_notary_status():
+    """
+    Get the notary service status (simplified version for health checks).
+
+    Returns a minimal status response suitable for health check integrations.
+    """
+    provenance_service = get_provenance_service()
+
+    return NotaryStatusResponse(
+        enabled=settings.NOTARY_ENABLED,
+        available=provenance_service.is_available,
+        address=provenance_service.notary_address
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from app.core.config import settings
 from app.core.version import VERSION
-from app.api.endpoints import stamps, data, wallet, pool
+from app.api.endpoints import stamps, data, wallet, pool, notary
 import logging
 
 # Configure basic logging
@@ -51,6 +51,7 @@ app.include_router(stamps.router, prefix=f"{settings.API_V1_STR}/stamps", tags=[
 app.include_router(data.router, prefix=f"{settings.API_V1_STR}/data", tags=["data"])
 app.include_router(wallet.router, prefix=f"{settings.API_V1_STR}", tags=["wallet"])
 app.include_router(pool.router, prefix=f"{settings.API_V1_STR}/pool", tags=["pool"])
+app.include_router(notary.router, prefix=f"{settings.API_V1_STR}/notary", tags=["notary"])
 
 @app.get("/", summary="Health Check", tags=["default"])
 @app.get("/health", summary="Health Check", tags=["default"], include_in_schema=False)


### PR DESCRIPTION
## Summary

- Create notary endpoint with /info and /status routes for querying notary availability
- Add `sign` parameter to data upload endpoint for gateway notary signing
- Support `sign=notary` to add cryptographic signature to uploaded documents
- Add comprehensive error handling for invalid sign options, invalid document formats, and missing configuration
- Register notary router in main app

## API Endpoints Added

### Notary Info
- `GET /api/v1/notary/info` - Get notary availability, public address, and usage instructions
- `GET /api/v1/notary/status` - Simplified status for health checks

### Data Upload Enhancement
- `POST /api/v1/data/?sign=notary` - Upload with gateway notary signature

## Usage

```bash
# Check notary availability
curl http://localhost:8000/api/v1/notary/info

# Upload with notary signing
curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=ABC123&sign=notary" \
     -F "file=@provenance-doc.json"
```

## Test plan

- [x] Notary info endpoint returns correct data when enabled/disabled
- [x] Notary status endpoint returns minimal status
- [x] Invalid sign option returns proper error
- [x] Invalid document format returns proper error
- [x] Valid document gets signed with notary signature

Closes #72