### PR TITLE
Add comprehensive tests for notary signing feature (Issue #74)

### DIFF
--- a/tests/test_notary_api.py
+++ b/tests/test_notary_api.py
@@ -1,0 +1,260 @@
+# tests/test_notary_api.py
+"""
+API integration tests for notary/provenance endpoints.
+"""
+import json
+import pytest
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+
+from app.main import app
+from app.services.provenance import ProvenanceService, SignedDocument
+
+
+class TestNotaryInfoEndpoint:
+    """Tests for GET /api/v1/notary/info endpoint."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return TestClient(app)
+
+    def test_info_when_disabled(self, client):
+        """Test notary info when disabled."""
+        with patch('app.api.endpoints.notary.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = False
+            response = client.get("/api/v1/notary/info")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is False
+        assert data["available"] is False
+        assert data["address"] is None
+        assert "not enabled" in data["message"].lower()
+
+    def test_info_when_enabled_but_not_configured(self, client):
+        """Test notary info when enabled but no key configured."""
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.is_available = False
+        mock_service.notary_address = None
+
+        with patch('app.api.endpoints.notary.settings') as mock_settings:
+            with patch('app.api.endpoints.notary.get_provenance_service', return_value=mock_service):
+                mock_settings.NOTARY_ENABLED = True
+                response = client.get("/api/v1/notary/info")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["available"] is False
+        assert data["address"] is None
+        assert "not configured" in data["message"].lower()
+
+    def test_info_when_fully_configured(self, client):
+        """Test notary info when fully configured."""
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.is_available = True
+        mock_service.notary_address = "0x1234567890abcdef"
+
+        with patch('app.api.endpoints.notary.settings') as mock_settings:
+            with patch('app.api.endpoints.notary.get_provenance_service', return_value=mock_service):
+                mock_settings.NOTARY_ENABLED = True
+                response = client.get("/api/v1/notary/info")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["enabled"] is True
+        assert data["available"] is True
+        assert data["address"] == "0x1234567890abcdef"
+        assert "available" in data["message"].lower()
+
+
+class TestNotaryStatusEndpoint:
+    """Tests for GET /api/v1/notary/status endpoint."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return TestClient(app)
+
+    def test_status_returns_simplified_response(self, client):
+        """Test that status returns minimal response."""
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.is_available = True
+        mock_service.notary_address = "0xabc"
+
+        with patch('app.api.endpoints.notary.settings') as mock_settings:
+            with patch('app.api.endpoints.notary.get_provenance_service', return_value=mock_service):
+                mock_settings.NOTARY_ENABLED = True
+                response = client.get("/api/v1/notary/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "enabled" in data
+        assert "available" in data
+        assert "address" in data
+        # Status should NOT have message field
+        assert "message" not in data
+
+
+class TestDataUploadWithSigning:
+    """Tests for POST /api/v1/data/?sign=notary endpoint."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return TestClient(app)
+
+    def test_sign_notary_invalid_sign_option(self, client):
+        """Test that invalid sign option returns error."""
+        with patch('app.api.endpoints.data.get_provenance_service') as mock:
+            mock.return_value = MagicMock(is_available=True)
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=invalid",
+                files={"file": ("test.json", json.dumps({"data": "test"}).encode('utf-8'), "application/json")}
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["code"] == "INVALID_SIGN_OPTION"
+
+    def test_sign_notary_when_not_enabled(self, client):
+        """Test signing when notary is not enabled."""
+        # Import to patch at module level
+        from app.services.provenance import NotaryNotEnabledError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = NotaryNotEnabledError("Not enabled")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"data": "test"}).encode('utf-8'), "application/json")}
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["code"] == "NOTARY_NOT_ENABLED"
+
+    def test_sign_notary_when_not_configured(self, client):
+        """Test signing when notary key is not configured."""
+        from app.services.signing import NotConfiguredError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = NotConfiguredError("No key")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"data": "test"}).encode('utf-8'), "application/json")}
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["code"] == "NOTARY_NOT_CONFIGURED"
+
+    def test_sign_notary_invalid_document_format(self, client):
+        """Test signing with invalid document format."""
+        from app.services.provenance import DocumentValidationError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = DocumentValidationError("Missing data field")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"invalid": "doc"}).encode('utf-8'), "application/json")}
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["code"] == "INVALID_DOCUMENT_FORMAT"
+
+    def test_upload_without_sign_preserved(self, client):
+        """Test that uploads without sign parameter work normally."""
+        # This test just verifies the endpoint doesn't error with no sign param
+        # The actual upload would need a real Swarm connection, so we just check parsing
+        response = client.post(
+            "/api/v1/data/?stamp_id=test_stamp",
+            files={"file": ("test.json", b'{"test": "data"}', "application/json")}
+        )
+
+        # Will fail due to Swarm connection, but not due to sign parameter
+        # We just want to ensure it's not a 400 related to signing
+        assert response.status_code != 400 or "sign" not in response.json().get("detail", {}).get("code", "").lower()
+
+
+class TestErrorResponseFormat:
+    """Tests for error response format consistency."""
+
+    @pytest.fixture
+    def client(self):
+        """Create a test client."""
+        return TestClient(app)
+
+    def test_error_response_has_code_and_message(self, client):
+        """Test that error responses have code and message."""
+        with patch('app.api.endpoints.data.get_provenance_service') as mock:
+            mock.return_value = MagicMock(is_available=True)
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=wrong",
+                files={"file": ("test.json", b'{"data": "test"}', "application/json")}
+            )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "detail" in data
+        assert "code" in data["detail"]
+        assert "message" in data["detail"]
+        assert "suggestion" in data["detail"]
+
+    def test_notary_not_enabled_error_format(self, client):
+        """Test error format when notary not enabled."""
+        from app.services.provenance import NotaryNotEnabledError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = NotaryNotEnabledError("Not enabled")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"data": "test"}).encode('utf-8'), "application/json")}
+            )
+
+        data = response.json()
+        assert data["detail"]["code"] == "NOTARY_NOT_ENABLED"
+        assert "NOTARY_ENABLED=true" in data["detail"]["suggestion"]
+
+    def test_notary_not_configured_error_format(self, client):
+        """Test error format when notary not configured."""
+        from app.services.signing import NotConfiguredError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = NotConfiguredError("No key")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"data": "test"}).encode('utf-8'), "application/json")}
+            )
+
+        data = response.json()
+        assert data["detail"]["code"] == "NOTARY_NOT_CONFIGURED"
+        assert "NOTARY_PRIVATE_KEY" in data["detail"]["suggestion"]
+
+    def test_invalid_document_error_format(self, client):
+        """Test error format for invalid document."""
+        from app.services.provenance import DocumentValidationError
+
+        mock_service = MagicMock(spec=ProvenanceService)
+        mock_service.sign_document.side_effect = DocumentValidationError("Missing data")
+
+        with patch('app.api.endpoints.data.get_provenance_service', return_value=mock_service):
+            response = client.post(
+                "/api/v1/data/?stamp_id=test_stamp&sign=notary",
+                files={"file": ("test.json", json.dumps({"no_data": "here"}).encode('utf-8'), "application/json")}
+            )
+
+        data = response.json()
+        assert data["detail"]["code"] == "INVALID_DOCUMENT_FORMAT"
+        assert "'data'" in data["detail"]["suggestion"]

--- a/tests/test_notary_provenance.py
+++ b/tests/test_notary_provenance.py
@@ -1,0 +1,425 @@
+# tests/test_notary_provenance.py
+"""
+Unit tests for the ProvenanceService (app/services/provenance.py).
+"""
+import json
+import pytest
+from datetime import datetime, timezone
+from eth_account import Account
+from unittest.mock import MagicMock, patch
+
+from app.services.provenance import (
+    ProvenanceService,
+    ProvenanceError,
+    DocumentValidationError,
+    NotaryNotEnabledError,
+    SignedDocument,
+    get_provenance_service,
+)
+from app.services.signing import SigningService, NotConfiguredError
+
+
+class TestDocumentValidation:
+    """Tests for document validation functionality."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a provenance service with a mock signing service."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = True
+        mock_signer.public_address = "0x" + "a" * 40
+        return ProvenanceService(mock_signer)
+
+    def test_validate_valid_document(self, service):
+        """Test validation of a valid document."""
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        document, data = service.validate_document(raw)
+
+        assert document == doc
+        assert data == {"test": "value"}
+
+    def test_validate_document_with_signatures(self, service):
+        """Test validation of document with existing signatures."""
+        doc = {
+            "data": {"test": "value"},
+            "signatures": [{"existing": "sig"}]
+        }
+        raw = json.dumps(doc).encode('utf-8')
+
+        document, data = service.validate_document(raw)
+
+        assert len(document["signatures"]) == 1
+
+    def test_validate_rejects_non_json(self, service):
+        """Test that non-JSON content is rejected."""
+        raw = b"not json content"
+
+        with pytest.raises(DocumentValidationError, match="valid JSON"):
+            service.validate_document(raw)
+
+    def test_validate_rejects_non_utf8(self, service):
+        """Test that non-UTF-8 content is rejected."""
+        raw = b"\xff\xfe invalid utf8"
+
+        with pytest.raises(DocumentValidationError, match="valid UTF-8"):
+            service.validate_document(raw)
+
+    def test_validate_rejects_non_object(self, service):
+        """Test that non-object JSON is rejected."""
+        raw = json.dumps([1, 2, 3]).encode('utf-8')
+
+        with pytest.raises(DocumentValidationError, match="JSON object"):
+            service.validate_document(raw)
+
+    def test_validate_rejects_missing_data_field(self, service):
+        """Test that missing data field is rejected."""
+        doc = {"other": "field"}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with pytest.raises(DocumentValidationError, match="'data' field"):
+            service.validate_document(raw)
+
+    def test_validate_rejects_invalid_signatures_type(self, service):
+        """Test that non-array signatures field is rejected."""
+        doc = {"data": "test", "signatures": "not an array"}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with pytest.raises(DocumentValidationError, match="must be an array"):
+            service.validate_document(raw)
+
+    def test_validate_accepts_any_data_type(self, service):
+        """Test that data field can be any JSON type."""
+        # String
+        doc = {"data": "string data"}
+        raw = json.dumps(doc).encode('utf-8')
+        _, data = service.validate_document(raw)
+        assert data == "string data"
+
+        # Number
+        doc = {"data": 123}
+        raw = json.dumps(doc).encode('utf-8')
+        _, data = service.validate_document(raw)
+        assert data == 123
+
+        # Array
+        doc = {"data": [1, 2, 3]}
+        raw = json.dumps(doc).encode('utf-8')
+        _, data = service.validate_document(raw)
+        assert data == [1, 2, 3]
+
+        # Object
+        doc = {"data": {"nested": "object"}}
+        raw = json.dumps(doc).encode('utf-8')
+        _, data = service.validate_document(raw)
+        assert data == {"nested": "object"}
+
+
+class TestSignDocument:
+    """Tests for document signing functionality."""
+
+    @pytest.fixture
+    def real_service(self):
+        """Create a provenance service with a real signing service."""
+        account = Account.create()
+        signer = SigningService(account.key.hex()[2:])
+        return ProvenanceService(signer), account.address
+
+    def test_sign_document_adds_signature(self, real_service):
+        """Test that signing adds a signature to the document."""
+        service, address = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch.object(type(service), 'is_available', property(lambda s: True)):
+            with patch('app.services.provenance.settings') as mock_settings:
+                mock_settings.NOTARY_ENABLED = True
+                result = service.sign_document(raw)
+
+        assert isinstance(result, SignedDocument)
+        assert len(result.signatures) == 1
+
+    def test_sign_document_preserves_existing_signatures(self, real_service):
+        """Test that existing signatures are preserved."""
+        service, address = real_service
+        doc = {
+            "data": {"test": "value"},
+            "signatures": [{"existing": "signature"}]
+        }
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch.object(type(service), 'is_available', property(lambda s: True)):
+            with patch('app.services.provenance.settings') as mock_settings:
+                mock_settings.NOTARY_ENABLED = True
+                result = service.sign_document(raw)
+
+        assert len(result.signatures) == 2
+        assert result.signatures[0] == {"existing": "signature"}
+
+    def test_sign_document_signature_structure(self, real_service):
+        """Test that notary signature has correct structure."""
+        service, address = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch.object(type(service), 'is_available', property(lambda s: True)):
+            with patch('app.services.provenance.settings') as mock_settings:
+                mock_settings.NOTARY_ENABLED = True
+                result = service.sign_document(raw)
+
+        sig = result.signatures[0]
+        assert sig["type"] == "notary"
+        # Check that signer is an Ethereum address format
+        assert sig["signer"].startswith("0x")
+        assert len(sig["signer"]) == 42
+        assert "timestamp" in sig
+        assert "data_hash" in sig
+        assert "signature" in sig
+        assert sig["signed_fields"] == ["data"]
+
+    def test_sign_document_with_custom_timestamp(self, real_service):
+        """Test signing with a custom timestamp."""
+        service, _ = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+        custom_time = datetime(2026, 1, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+        with patch.object(type(service), 'is_available', property(lambda s: True)):
+            with patch('app.services.provenance.settings') as mock_settings:
+                mock_settings.NOTARY_ENABLED = True
+                result = service.sign_document(raw, custom_time)
+
+        sig = result.signatures[0]
+        assert "2026-01-21T12:00:00" in sig["timestamp"]
+
+    def test_sign_document_returns_valid_json(self, real_service):
+        """Test that raw_json is valid JSON."""
+        service, _ = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch.object(type(service), 'is_available', property(lambda s: True)):
+            with patch('app.services.provenance.settings') as mock_settings:
+                mock_settings.NOTARY_ENABLED = True
+                result = service.sign_document(raw)
+
+        # Should parse without error
+        parsed = json.loads(result.raw_json)
+        assert "data" in parsed
+        assert "signatures" in parsed
+
+    def test_sign_document_fails_when_not_enabled(self):
+        """Test that signing fails when notary is not enabled."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = True
+        service = ProvenanceService(mock_signer)
+
+        doc = {"data": "test"}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = False
+            with pytest.raises(NotaryNotEnabledError):
+                service.sign_document(raw)
+
+    def test_sign_document_fails_when_not_configured(self):
+        """Test that signing fails when signer is not configured."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = False
+        service = ProvenanceService(mock_signer)
+
+        doc = {"data": "test"}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            with pytest.raises(NotConfiguredError):
+                service.sign_document(raw)
+
+    def test_sign_invalid_document_fails(self, real_service):
+        """Test that signing invalid document fails."""
+        service, _ = real_service
+        raw = b"not json"
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            with pytest.raises(DocumentValidationError):
+                service.sign_document(raw)
+
+
+class TestVerifyNotarySignature:
+    """Tests for signature verification."""
+
+    @pytest.fixture
+    def real_service(self):
+        """Create a provenance service with a real signing service."""
+        account = Account.create()
+        signer = SigningService(account.key.hex()[2:])
+        return ProvenanceService(signer), account.address
+
+    def test_verify_valid_signature(self, real_service):
+        """Test verification of a valid signature."""
+        service, _ = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            signed = service.sign_document(raw)
+
+        # Get the signer address from the signed document
+        signer_address = signed.signatures[-1]["signer"]
+
+        # Verify the signed document using the address from the signature
+        is_valid, error = service.verify_notary_signature(
+            signed.raw_json.encode('utf-8'),
+            signer_address
+        )
+
+        assert is_valid is True
+        assert error is None
+
+    def test_verify_wrong_signer_fails(self, real_service):
+        """Test verification fails with wrong expected signer."""
+        service, address = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            signed = service.sign_document(raw)
+
+        wrong_address = "0x" + "b" * 40
+        is_valid, error = service.verify_notary_signature(
+            signed.raw_json.encode('utf-8'),
+            wrong_address
+        )
+
+        assert is_valid is False
+        assert "mismatch" in error.lower()
+
+    def test_verify_tampered_data_fails(self, real_service):
+        """Test verification fails if data was modified."""
+        service, address = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            signed = service.sign_document(raw)
+
+        # Get the signer address from the signed document
+        signer_address = signed.signatures[-1]["signer"]
+
+        # Tamper with the signed document
+        tampered = json.loads(signed.raw_json)
+        tampered["data"]["test"] = "tampered"
+        tampered_raw = json.dumps(tampered).encode('utf-8')
+
+        is_valid, error = service.verify_notary_signature(
+            tampered_raw,
+            signer_address
+        )
+
+        assert is_valid is False
+        assert "hash mismatch" in error.lower()
+
+    def test_verify_no_signatures_fails(self, real_service):
+        """Test verification fails when no signatures present."""
+        service, _ = real_service
+        doc = {"data": {"test": "value"}}
+        raw = json.dumps(doc).encode('utf-8')
+
+        is_valid, error = service.verify_notary_signature(raw)
+
+        assert is_valid is False
+        assert "no signatures" in error.lower()
+
+    def test_verify_no_notary_signature_fails(self, real_service):
+        """Test verification fails when no notary signature present."""
+        service, _ = real_service
+        doc = {
+            "data": {"test": "value"},
+            "signatures": [{"type": "other", "value": "xxx"}]
+        }
+        raw = json.dumps(doc).encode('utf-8')
+
+        is_valid, error = service.verify_notary_signature(raw)
+
+        assert is_valid is False
+        assert "no notary signature" in error.lower()
+
+
+class TestProvenanceServiceProperties:
+    """Tests for ProvenanceService properties."""
+
+    def test_is_available_when_enabled_and_configured(self):
+        """Test is_available returns True when properly configured."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = True
+        service = ProvenanceService(mock_signer)
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            assert service.is_available is True
+
+    def test_is_available_false_when_disabled(self):
+        """Test is_available returns False when disabled."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = True
+        service = ProvenanceService(mock_signer)
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = False
+            assert service.is_available is False
+
+    def test_is_available_false_when_not_configured(self):
+        """Test is_available returns False when not configured."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = False
+        service = ProvenanceService(mock_signer)
+
+        with patch('app.services.provenance.settings') as mock_settings:
+            mock_settings.NOTARY_ENABLED = True
+            assert service.is_available is False
+
+    def test_notary_address_when_configured(self):
+        """Test notary_address returns address when configured."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = True
+        mock_signer.public_address = "0x123"
+        service = ProvenanceService(mock_signer)
+
+        assert service.notary_address == "0x123"
+
+    def test_notary_address_none_when_not_configured(self):
+        """Test notary_address returns None when not configured."""
+        mock_signer = MagicMock(spec=SigningService)
+        mock_signer.is_configured = False
+        service = ProvenanceService(mock_signer)
+
+        assert service.notary_address is None
+
+
+class TestGetProvenanceService:
+    """Tests for get_provenance_service singleton."""
+
+    def test_get_provenance_service_returns_service(self):
+        """Test that get_provenance_service returns a ProvenanceService."""
+        import app.services.provenance as provenance_module
+        provenance_module._provenance_service = None
+
+        service = get_provenance_service()
+
+        assert isinstance(service, ProvenanceService)
+
+    def test_get_provenance_service_returns_same_instance(self):
+        """Test that get_provenance_service returns singleton."""
+        import app.services.provenance as provenance_module
+        provenance_module._provenance_service = None
+
+        service1 = get_provenance_service()
+        service2 = get_provenance_service()
+
+        assert service1 is service2

--- a/tests/test_notary_signing.py
+++ b/tests/test_notary_signing.py
@@ -1,0 +1,279 @@
+# tests/test_notary_signing.py
+"""
+Unit tests for the SigningService (app/services/signing.py).
+"""
+import hashlib
+import pytest
+from datetime import datetime, timezone
+from eth_account import Account
+
+from app.services.signing import (
+    SigningService,
+    SigningServiceError,
+    NotConfiguredError,
+    get_signing_service,
+)
+
+
+class TestSigningServiceInit:
+    """Tests for SigningService initialization."""
+
+    def test_init_with_valid_key(self):
+        """Test initialization with a valid private key."""
+        account = Account.create()
+        key_hex = account.key.hex()  # With 0x prefix
+
+        # Create service with the same key
+        service = SigningService(key_hex)
+
+        assert service.is_configured is True
+        # Both should derive from the same key
+        assert service.public_address.lower() == account.address.lower()
+
+    def test_init_with_key_with_0x_prefix(self):
+        """Test initialization handles 0x prefix correctly."""
+        account = Account.create()
+        key_hex = account.key.hex()  # With 0x prefix
+
+        service = SigningService(key_hex)
+
+        assert service.is_configured is True
+        assert service.public_address == account.address
+
+    def test_init_with_short_key_pads_correctly(self):
+        """Test that short keys are zero-padded to 32 bytes."""
+        # Very short key (will be padded)
+        short_key = "1234"
+
+        service = SigningService(short_key)
+
+        assert service.is_configured is True
+        assert service.public_address is not None
+
+    def test_init_with_no_key_not_configured(self):
+        """Test that service without key is not configured."""
+        service = SigningService(None)
+
+        assert service.is_configured is False
+        assert service.public_address is None
+
+    def test_init_with_invalid_key_raises_error(self):
+        """Test that invalid key raises SigningServiceError."""
+        with pytest.raises(SigningServiceError, match="Invalid private key"):
+            SigningService("not-a-valid-hex-key")
+
+
+class TestSigningServiceHashing:
+    """Tests for SigningService hashing functionality."""
+
+    def test_hash_data_returns_sha256(self):
+        """Test that hash_data returns correct SHA-256 hash."""
+        data = b"test data"
+        expected = hashlib.sha256(data).hexdigest()
+
+        result = SigningService.hash_data(data)
+
+        assert result == expected
+
+    def test_hash_data_is_deterministic(self):
+        """Test that hashing is deterministic."""
+        data = b"test data"
+
+        hash1 = SigningService.hash_data(data)
+        hash2 = SigningService.hash_data(data)
+
+        assert hash1 == hash2
+
+    def test_hash_data_different_inputs_different_hashes(self):
+        """Test that different inputs produce different hashes."""
+        hash1 = SigningService.hash_data(b"data1")
+        hash2 = SigningService.hash_data(b"data2")
+
+        assert hash1 != hash2
+
+    def test_hash_data_empty_input(self):
+        """Test hashing empty data."""
+        expected = hashlib.sha256(b"").hexdigest()
+
+        result = SigningService.hash_data(b"")
+
+        assert result == expected
+
+
+class TestSigningServiceSigning:
+    """Tests for SigningService signing functionality."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a signing service with a test key."""
+        account = Account.create()
+        return SigningService(account.key.hex()[2:])
+
+    def test_sign_with_timestamp_returns_tuple(self, service):
+        """Test that sign_with_timestamp returns correct tuple structure."""
+        data = b"test data"
+
+        result = service.sign_with_timestamp(data)
+
+        assert len(result) == 4
+        data_hash, timestamp, signature, address = result
+
+        assert isinstance(data_hash, str)
+        assert isinstance(timestamp, str)
+        assert isinstance(signature, str)
+        assert isinstance(address, str)
+
+    def test_sign_with_timestamp_hash_is_correct(self, service):
+        """Test that returned hash matches data."""
+        data = b"test data"
+        expected_hash = SigningService.hash_data(data)
+
+        data_hash, _, _, _ = service.sign_with_timestamp(data)
+
+        assert data_hash == expected_hash
+
+    def test_sign_with_timestamp_address_matches_service(self, service):
+        """Test that returned address matches service address."""
+        data = b"test data"
+
+        _, _, _, address = service.sign_with_timestamp(data)
+
+        assert address == service.public_address
+
+    def test_sign_with_timestamp_iso_format(self, service):
+        """Test that timestamp is ISO 8601 format."""
+        data = b"test data"
+
+        _, timestamp, _, _ = service.sign_with_timestamp(data)
+
+        # Should contain T for ISO format
+        assert "T" in timestamp
+        # Should parse without error
+        datetime.fromisoformat(timestamp.replace("+00:00", "+00:00"))
+
+    def test_sign_with_custom_timestamp(self, service):
+        """Test signing with a custom timestamp."""
+        data = b"test data"
+        custom_time = datetime(2026, 1, 21, 12, 0, 0, tzinfo=timezone.utc)
+
+        _, timestamp, _, _ = service.sign_with_timestamp(data, custom_time)
+
+        assert "2026-01-21T12:00:00" in timestamp
+
+    def test_sign_unconfigured_raises_error(self):
+        """Test that signing without configuration raises error."""
+        service = SigningService(None)
+
+        with pytest.raises(NotConfiguredError):
+            service.sign_with_timestamp(b"test")
+
+
+class TestSigningServiceVerification:
+    """Tests for signature verification."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a signing service with a test key."""
+        account = Account.create()
+        return SigningService(account.key.hex()[2:])
+
+    def test_verify_valid_signature(self, service):
+        """Test verification of a valid signature."""
+        data = b"test data"
+        data_hash, timestamp, signature, address = service.sign_with_timestamp(data)
+
+        is_valid = SigningService.verify_signature(
+            data_hash, timestamp, signature, address
+        )
+
+        assert is_valid is True
+
+    def test_verify_wrong_address_fails(self, service):
+        """Test verification fails with wrong address."""
+        data = b"test data"
+        data_hash, timestamp, signature, _ = service.sign_with_timestamp(data)
+
+        wrong_address = "0x" + "0" * 40
+
+        is_valid = SigningService.verify_signature(
+            data_hash, timestamp, signature, wrong_address
+        )
+
+        assert is_valid is False
+
+    def test_verify_tampered_hash_fails(self, service):
+        """Test verification fails if hash is tampered."""
+        data = b"test data"
+        data_hash, timestamp, signature, address = service.sign_with_timestamp(data)
+
+        tampered_hash = "0" * 64
+
+        is_valid = SigningService.verify_signature(
+            tampered_hash, timestamp, signature, address
+        )
+
+        assert is_valid is False
+
+    def test_verify_tampered_timestamp_fails(self, service):
+        """Test verification fails if timestamp is tampered."""
+        data = b"test data"
+        data_hash, timestamp, signature, address = service.sign_with_timestamp(data)
+
+        tampered_timestamp = "2099-12-31T23:59:59+00:00"
+
+        is_valid = SigningService.verify_signature(
+            data_hash, tampered_timestamp, signature, address
+        )
+
+        assert is_valid is False
+
+    def test_verify_invalid_signature_fails(self, service):
+        """Test verification fails with invalid signature."""
+        data = b"test data"
+        data_hash, timestamp, _, address = service.sign_with_timestamp(data)
+
+        invalid_signature = "0x" + "0" * 130
+
+        is_valid = SigningService.verify_signature(
+            data_hash, timestamp, invalid_signature, address
+        )
+
+        assert is_valid is False
+
+    def test_verify_signature_without_0x_prefix(self, service):
+        """Test verification works with signature without 0x prefix."""
+        data = b"test data"
+        data_hash, timestamp, signature, address = service.sign_with_timestamp(data)
+
+        # Remove 0x prefix if present
+        sig_without_prefix = signature[2:] if signature.startswith("0x") else signature
+
+        is_valid = SigningService.verify_signature(
+            data_hash, timestamp, sig_without_prefix, address
+        )
+
+        assert is_valid is True
+
+
+class TestGetSigningService:
+    """Tests for get_signing_service singleton."""
+
+    def test_get_signing_service_returns_service(self, monkeypatch):
+        """Test that get_signing_service returns a SigningService instance."""
+        # Reset singleton
+        import app.services.signing as signing_module
+        signing_module._signing_service = None
+
+        service = get_signing_service()
+
+        assert isinstance(service, SigningService)
+
+    def test_get_signing_service_returns_same_instance(self, monkeypatch):
+        """Test that get_signing_service returns singleton."""
+        import app.services.signing as signing_module
+        signing_module._signing_service = None
+
+        service1 = get_signing_service()
+        service2 = get_signing_service()
+
+        assert service1 is service2


### PR DESCRIPTION
## Summary
- Added comprehensive test suite for the notary signing feature
- **64 tests** covering all notary components:
  - `test_notary_signing.py`: Unit tests for SigningService (23 tests)
  - `test_notary_provenance.py`: Unit tests for ProvenanceService (28 tests)
  - `test_notary_api.py`: API integration tests (13 tests)

## Test Coverage

### SigningService (`test_notary_signing.py`)
- Initialization (valid key, 0x prefix handling, short key padding, invalid key)
- Hashing (SHA-256 correctness, determinism, different inputs)
- Signing (timestamp format, address matching, custom timestamp)
- Verification (valid signature, wrong address, tampered hash/timestamp)

### ProvenanceService (`test_notary_provenance.py`)
- Document validation (JSON, UTF-8, data field, signatures array)
- Signing (add signature, preserve existing, signature structure)
- Verification (valid, wrong signer, tampered data, missing signatures)
- Service properties (is_available, notary_address)

### API Endpoints (`test_notary_api.py`)
- `/api/v1/notary/info` (disabled, enabled, configured states)
- `/api/v1/notary/status` (simplified response)
- `POST /api/v1/data/?sign=notary` (error scenarios)
- Error response format consistency

## Test Results
All 64 tests pass.

Closes #74