### PR TITLE
Fix: Preserve all document fields when adding notary signature

### DIFF
--- a/app/services/provenance.py
+++ b/app/services/provenance.py
@@ -135,6 +135,15 @@ class ProvenanceService:
             if not isinstance(document["signatures"], list):
                 raise DocumentValidationError("'signatures' field must be an array")
 
+        # Log guidance for SWIP compliance (non-blocking)
+        swip_fields = ["content_hash", "provenance_standard", "encryption", "stamp_id"]
+        missing_swip = [f for f in swip_fields if f not in document]
+        if missing_swip:
+            logger.debug(
+                f"Document missing optional SWIP fields: {missing_swip}. "
+                "Consider using SWIP-37 compliant structure for future compatibility."
+            )
+
         return document, document["data"]
 
     def sign_document(
@@ -188,11 +197,9 @@ class ProvenanceService:
         # Get existing signatures or create empty array
         existing_signatures = document.get("signatures", [])
 
-        # Create output document
-        output_document = {
-            "data": data_value,
-            "signatures": existing_signatures + [notary_signature]
-        }
+        # Create output document - preserve all original fields, update signatures
+        output_document = document.copy()
+        output_document["signatures"] = existing_signatures + [notary_signature]
 
         # Serialize to JSON
         output_json = json.dumps(output_document, indent=2)


### PR DESCRIPTION
## Summary
- Fixes output document to preserve all original fields (content_hash, provenance_standard, encryption, stamp_id, etc.) when adding notary signature
- Previously only kept `data` and `signatures` fields, dropping other SWIP-37 fields
- Adds debug logging for missing optional SWIP-37 fields (non-blocking guidance)

## Changes
- `app/services/provenance.py`: Use `document.copy()` instead of creating new dict with only `data` and `signatures`
- Add SWIP compliance logging at debug level for missing optional fields

## Related Issues
- Epic #69: Simple Provenance Signing
- Addresses SWIP-37 document structure compliance

## Test Plan
- [x] All 51 notary tests pass
- [x] Verified document fields are preserved in signed output