### PR TITLE
Clarify signature field naming: hashed_fields + signed_message_format

### DIFF
--- a/app/services/provenance.py
+++ b/app/services/provenance.py
@@ -44,7 +44,8 @@ class NotarySignature:
     timestamp: str  # ISO 8601
     data_hash: str  # SHA-256 of data field
     signature: str  # EIP-191 signature
-    signed_fields: List[str]  # Fields that were signed
+    hashed_fields: List[str]  # Fields that were hashed to create data_hash
+    signed_message_format: str  # Format of the EIP-191 signed message
 
 
 @dataclass
@@ -76,7 +77,8 @@ class ProvenanceService:
                 "timestamp": "2026-01-21T14:00:00Z",
                 "data_hash": "abc123...",
                 "signature": "def456...",
-                "signed_fields": ["data"]
+                "hashed_fields": ["data"],
+                "signed_message_format": "{data_hash}|{timestamp}"
             }
         ]
     }
@@ -191,7 +193,8 @@ class ProvenanceService:
             "timestamp": timestamp_iso,
             "data_hash": data_hash,
             "signature": signature,
-            "signed_fields": ["data"]
+            "hashed_fields": ["data"],  # Fields that were hashed to create data_hash
+            "signed_message_format": "{data_hash}|{timestamp}"  # Actual EIP-191 signed message
         }
 
         # Get existing signatures or create empty array

--- a/docs/notary-guide.md
+++ b/docs/notary-guide.md
@@ -87,7 +87,8 @@ The returned document includes the notary signature:
       "timestamp": "2026-01-21T14:30:00+00:00",
       "data_hash": "abc123...def456",
       "signature": "0x...",
-      "signed_fields": ["data"]
+      "hashed_fields": ["data"],
+      "signed_message_format": "{data_hash}|{timestamp}"
     }
   ]
 }
@@ -98,8 +99,9 @@ The returned document includes the notary signature:
 - `signer`: The gateway's Ethereum address (matches `/notary/info`)
 - `timestamp`: ISO 8601 timestamp when the document was signed
 - `data_hash`: SHA-256 hash of the canonical JSON `data` field
-- `signature`: EIP-191 signature of `"data_hash|timestamp"`
-- `signed_fields`: Which fields were included in the hash (always `["data"]`)
+- `signature`: EIP-191 signature of the message `"data_hash|timestamp"`
+- `hashed_fields`: Which document fields were hashed to create `data_hash` (always `["data"]`)
+- `signed_message_format`: The format of the actual signed message (always `"{data_hash}|{timestamp}"`)
 
 ---
 
@@ -167,7 +169,8 @@ file: <your JSON document>
       "timestamp": "2026-01-21T14:30:00+00:00",
       "data_hash": "...",
       "signature": "...",
-      "signed_fields": ["data"]
+      "hashed_fields": ["data"],
+      "signed_message_format": "{data_hash}|{timestamp}"
     }
   ]
 }
@@ -247,7 +250,8 @@ document = {
             "timestamp": "2026-01-21T14:30:00+00:00",
             "data_hash": "abc123...",
             "signature": "0x...",
-            "signed_fields": ["data"]
+            "hashed_fields": ["data"],
+            "signed_message_format": "{data_hash}|{timestamp}"
         }
     ]
 }

--- a/tests/test_notary_provenance.py
+++ b/tests/test_notary_provenance.py
@@ -176,7 +176,8 @@ class TestSignDocument:
         assert "timestamp" in sig
         assert "data_hash" in sig
         assert "signature" in sig
-        assert sig["signed_fields"] == ["data"]
+        assert sig["hashed_fields"] == ["data"]
+        assert sig["signed_message_format"] == "{data_hash}|{timestamp}"
 
     def test_sign_document_with_custom_timestamp(self, real_service):
         """Test signing with a custom timestamp."""


### PR DESCRIPTION
## Summary

Based on CLI developer feedback, this PR clarifies the notary signature field naming to more accurately describe what is being signed vs what is being hashed.

**BREAKING CHANGE**: Renamed `signed_fields` to `hashed_fields` in notary signature structure.

### Changes

- Renamed `signed_fields` to `hashed_fields` - clarifies these are the fields that were hashed to create `data_hash`
- Added `signed_message_format` field - shows the actual EIP-191 message format: `{data_hash}|{timestamp}`

### Why

The previous `signed_fields: ["data"]` was misleading because:
- It implied only the `data` field was signed
- In reality, the signature covers `{data_hash}|{timestamp}` - the hash AND the timestamp

The new naming makes it clear:
- `hashed_fields: ["data"]` - which fields contributed to the hash
- `signed_message_format: "{data_hash}|{timestamp}"` - what was actually signed (including timestamp)

### New Signature Structure

```json
{
  "type": "notary",
  "signer": "0x...",
  "timestamp": "2026-01-22T14:30:00+00:00",
  "data_hash": "abc123...",
  "signature": "0x...",
  "hashed_fields": ["data"],
  "signed_message_format": "{data_hash}|{timestamp}"
}
```

### Test Plan

- [x] All 28 notary tests pass
- [x] Updated tests to verify new field names
- [x] Updated documentation with new examples