### PR TITLE
Add immediate pool replenishment after stamp acquisition

### DIFF
--- a/app/api/endpoints/pool.py
+++ b/app/api/endpoints/pool.py
@@ -211,6 +211,12 @@ async def acquire_stamp(
             fallback_used=False
         )
 
+    # Trigger immediate replenishment if pool is below target
+    # This runs in the background and doesn't affect the response
+    replenishment_triggered = stamp_pool_manager.trigger_replenishment_if_needed(released.depth)
+    if replenishment_triggered:
+        logger.info(f"Triggered immediate replenishment for depth {released.depth}")
+
     size_name = depth_to_size_name(released.depth)
 
     message = f"Stamp acquired from pool (depth={released.depth}, size={size_name})"

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -76,6 +76,10 @@ class Settings(BaseSettings):
     # Stamp duration for new pool stamps (in hours)
     STAMP_POOL_DEFAULT_DURATION_HOURS: int = 168  # 1 week default for pool stamps
 
+    # Immediate replenishment: when true, purchasing a replacement stamp starts
+    # immediately (async) when a stamp is released from the pool
+    STAMP_POOL_IMMEDIATE_REPLENISH: bool = True
+
     # === Notary/Provenance Signing Settings ===
     # The notary feature allows the gateway to sign documents with an authoritative timestamp.
     # This provides proof that a document existed at a specific time, signed by the gateway.

--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -79,6 +79,7 @@ class StampPoolManager:
         self._task: Optional[asyncio.Task] = None
         self._last_check: Optional[datetime] = None
         self._errors: List[str] = []
+        self._pending_replenishments: Dict[int, int] = {}  # depth -> count of pending purchases
 
     @property
     def is_enabled(self) -> bool:
@@ -200,6 +201,87 @@ class StampPoolManager:
             del self._pool[batch_id]
 
             return stamp
+
+    def trigger_replenishment_if_needed(self, depth: int) -> bool:
+        """
+        Check if replenishment is needed for the given depth and trigger async purchase.
+
+        This is called after a stamp is released to immediately start purchasing
+        a replacement if the reserve count is below target.
+
+        Args:
+            depth: The depth of the stamp that was just released
+
+        Returns:
+            True if a replenishment task was triggered, False otherwise
+        """
+        if not settings.STAMP_POOL_IMMEDIATE_REPLENISH:
+            logger.debug(f"Immediate replenishment disabled, skipping for depth {depth}")
+            return False
+
+        reserve_config = self.get_reserve_config()
+        target_count = reserve_config.get(depth, 0)
+
+        if target_count == 0:
+            # This depth is not configured for pooling
+            return False
+
+        # Count current available stamps for this depth
+        with self._lock:
+            current_count = len([
+                s for s in self._pool.values()
+                if s.depth == depth and s.status == PoolStampStatus.AVAILABLE
+            ])
+            pending_count = self._pending_replenishments.get(depth, 0)
+
+        # If we're at or above target (including pending), no action needed
+        effective_count = current_count + pending_count
+        if effective_count >= target_count:
+            logger.debug(
+                f"Pool depth {depth}: no replenishment needed "
+                f"(have {current_count}, pending {pending_count}, target {target_count})"
+            )
+            return False
+
+        # Need to replenish - spawn async task
+        logger.info(
+            f"Pool depth {depth}: triggering immediate replenishment "
+            f"(have {current_count}, pending {pending_count}, target {target_count})"
+        )
+
+        # Track pending replenishment
+        with self._lock:
+            self._pending_replenishments[depth] = pending_count + 1
+
+        # Spawn fire-and-forget async task
+        asyncio.create_task(self._async_replenish_one(depth))
+
+        return True
+
+    async def _async_replenish_one(self, depth: int):
+        """
+        Async task to purchase one stamp for replenishment.
+
+        This is fire-and-forget - errors are logged but don't affect the caller.
+        """
+        try:
+            logger.info(f"Immediate replenishment: starting purchase for depth {depth}")
+            batch_id = await self._purchase_stamp(depth)
+            if batch_id:
+                logger.info(f"Immediate replenishment: successfully purchased stamp {batch_id[:16]}... for depth {depth}")
+            else:
+                logger.warning(f"Immediate replenishment: purchase returned no batch_id for depth {depth}")
+        except Exception as e:
+            logger.error(f"Immediate replenishment failed for depth {depth}: {e}")
+            self._errors.append(f"Immediate replenishment failed (depth {depth}): {str(e)}")
+        finally:
+            # Remove from pending count
+            with self._lock:
+                current_pending = self._pending_replenishments.get(depth, 1)
+                if current_pending <= 1:
+                    self._pending_replenishments.pop(depth, None)
+                else:
+                    self._pending_replenishments[depth] = current_pending - 1
 
     def add_stamp_to_pool(self, batch_id: str, depth: int, amount: int, ttl: int, label: Optional[str] = None) -> PoolStamp:
         """

--- a/tests/test_stamp_pool.py
+++ b/tests/test_stamp_pool.py
@@ -318,6 +318,104 @@ class TestPoolAPIDisabled:
             assert response.status_code == 503
 
 
+class TestImmediateReplenishment:
+    """Test immediate replenishment after stamp release."""
+
+    @pytest.fixture
+    def manager(self):
+        """Create a fresh StampPoolManager for each test."""
+        return StampPoolManager()
+
+    def test_trigger_replenishment_when_below_target(self, manager):
+        """Test that replenishment is triggered when pool drops below target."""
+        # Add a stamp and configure target to 1
+        manager.add_stamp_to_pool("stamp17", 17, 1000000, 604800)
+
+        with patch.object(manager, 'get_reserve_config', return_value={17: 1}):
+            with patch('app.services.stamp_pool.settings') as mock_settings:
+                mock_settings.STAMP_POOL_IMMEDIATE_REPLENISH = True
+
+                # Release the stamp, pool is now at 0, below target 1
+                manager.release_stamp("stamp17")
+
+                # Now trigger should return True (needs replenishment)
+                # Need to mock asyncio.create_task to prevent actual task creation
+                with patch('asyncio.create_task') as mock_create_task:
+                    triggered = manager.trigger_replenishment_if_needed(17)
+                    assert triggered is True
+                    mock_create_task.assert_called_once()
+
+    def test_no_trigger_when_at_target(self, manager):
+        """Test no replenishment triggered when pool is at target."""
+        # Add two stamps
+        manager.add_stamp_to_pool("stamp17a", 17, 1000000, 604800)
+        manager.add_stamp_to_pool("stamp17b", 17, 1000000, 604800)
+
+        with patch.object(manager, 'get_reserve_config', return_value={17: 1}):
+            with patch('app.services.stamp_pool.settings') as mock_settings:
+                mock_settings.STAMP_POOL_IMMEDIATE_REPLENISH = True
+
+                # Release one stamp, pool is now at 1, equal to target 1
+                manager.release_stamp("stamp17a")
+
+                # Should not trigger - we're at target
+                triggered = manager.trigger_replenishment_if_needed(17)
+                assert triggered is False
+
+    def test_no_trigger_when_disabled(self, manager):
+        """Test no replenishment when immediate replenishment is disabled."""
+        manager.add_stamp_to_pool("stamp17", 17, 1000000, 604800)
+
+        with patch.object(manager, 'get_reserve_config', return_value={17: 1}):
+            with patch('app.services.stamp_pool.settings') as mock_settings:
+                mock_settings.STAMP_POOL_IMMEDIATE_REPLENISH = False
+
+                # Release the stamp
+                manager.release_stamp("stamp17")
+
+                # Should not trigger - feature disabled
+                triggered = manager.trigger_replenishment_if_needed(17)
+                assert triggered is False
+
+    def test_no_trigger_for_unconfigured_depth(self, manager):
+        """Test no replenishment for depths not in reserve config."""
+        manager.add_stamp_to_pool("stamp22", 22, 1000000, 604800)
+
+        with patch.object(manager, 'get_reserve_config', return_value={17: 1, 20: 1}):  # No 22
+            with patch('app.services.stamp_pool.settings') as mock_settings:
+                mock_settings.STAMP_POOL_IMMEDIATE_REPLENISH = True
+
+                # Release the stamp
+                manager.release_stamp("stamp22")
+
+                # Should not trigger - depth 22 not configured
+                triggered = manager.trigger_replenishment_if_needed(22)
+                assert triggered is False
+
+    def test_pending_replenishments_tracked(self, manager):
+        """Test that pending replenishments are tracked to avoid over-ordering."""
+        with patch.object(manager, 'get_reserve_config', return_value={17: 2}):
+            with patch('app.services.stamp_pool.settings') as mock_settings:
+                mock_settings.STAMP_POOL_IMMEDIATE_REPLENISH = True
+
+                with patch('asyncio.create_task') as mock_create_task:
+                    # First trigger should succeed
+                    triggered1 = manager.trigger_replenishment_if_needed(17)
+                    assert triggered1 is True
+                    assert manager._pending_replenishments.get(17) == 1
+
+                    # Second trigger should also succeed since we need 2
+                    triggered2 = manager.trigger_replenishment_if_needed(17)
+                    assert triggered2 is True
+                    assert manager._pending_replenishments.get(17) == 2
+
+                    # Third trigger should fail - we have 2 pending, target is 2
+                    triggered3 = manager.trigger_replenishment_if_needed(17)
+                    assert triggered3 is False
+
+                    assert mock_create_task.call_count == 2
+
+
 class TestLowReserveWarning:
     """Test low reserve warning logic."""
 


### PR DESCRIPTION
## Summary
- Implements immediate async replenishment when a stamp is acquired from the pool
- Pool automatically triggers a background purchase task when levels drop below target
- Tracks pending replenishments to avoid over-ordering multiple stamps

## Changes
- Add `STAMP_POOL_IMMEDIATE_REPLENISH` config option (default: `true`)
- Add `trigger_replenishment_if_needed()` method to `StampPoolManager`
- Add `_async_replenish_one()` for fire-and-forget stamp purchase
- Update acquire endpoint to call replenishment trigger after release
- Add comprehensive unit tests (5 new tests)

## Test plan
- [x] Run `pytest tests/test_stamp_pool.py -v` - all 31 tests pass
- [x] Test replenishment triggers when pool drops below target
- [x] Test no trigger when pool is at/above target
- [x] Test config disable works
- [x] Test unconfigured depths are skipped
- [x] Test pending count prevents over-ordering

Closes #80