### PR TITLE
Add CORS middleware for browser-based SDK usage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,16 @@ SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
 # API_KEY=
 # API_KEY_NAME=X-API-Key
 
+# === CORS Settings ===
+# Required for browser-based SDK usage (React, Vite, etc.)
+#
+# CORS_ALLOWED_ORIGINS=*                           # "*" for all origins, or comma-separated list
+# CORS_ALLOW_CREDENTIALS=false                     # Must be false when using "*" origins
+#
+# Production example with specific origins:
+# CORS_ALLOWED_ORIGINS=https://app.datafund.io,https://fairdrop.datafund.io,https://verity.datafund.io
+# CORS_ALLOW_CREDENTIALS=true
+
 # === Stamp Pool (Optional) ===
 # Pre-purchased stamp reserve for instant acquisition (<5 sec vs >1 min)
 # See docs/stamp-pool-guide.md for full documentation

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,8 @@ jobs:
           STAMP_POOL_DEFAULT_DURATION_HOURS=${{ vars.STAMP_POOL_DEFAULT_DURATION_HOURS || '168' }}
           NOTARY_ENABLED=${{ vars.NOTARY_ENABLED || 'false' }}
           NOTARY_PRIVATE_KEY=${{ secrets.NOTARY_PRIVATE_KEY || '' }}
+          CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS || '*' }}
+          CORS_ALLOW_CREDENTIALS=${{ vars.CORS_ALLOW_CREDENTIALS || 'false' }}
           EOF
 
       - name: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@ Notary signing (optional):
 - `NOTARY_ENABLED`: Enable notary signing feature (default: `false`)
 - `NOTARY_PRIVATE_KEY`: Hex-encoded Ethereum private key for signing (64 characters, no 0x prefix)
 
+CORS (browser access):
+- `CORS_ALLOWED_ORIGINS`: Allowed origins, `*` for all or comma-separated list (default: `*`)
+- `CORS_ALLOW_CREDENTIALS`: Allow credentials in CORS requests (default: `false`)
+
 ### API Endpoints
 
 #### Core Endpoints
@@ -132,7 +136,7 @@ Notary signing (optional):
 ### Development Notes
 
 - Tests are implemented using pytest with mocking (see `tests/` directory)
-- CORS middleware is commented out but ready to enable
+- CORS middleware enabled by default for browser-based SDK usage
 - Authentication/authorization placeholder code exists but not implemented
 - SSL/HTTPS support built into development server
 - Logging configured at INFO level with structured error handling

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -86,6 +86,20 @@ class Settings(BaseSettings):
     NOTARY_ENABLED: bool = False  # Master switch for notary signing feature
     NOTARY_PRIVATE_KEY: Optional[str] = None  # Hex-encoded private key for signing (without 0x prefix)
 
+    # === CORS Settings ===
+    # Enable CORS for browser-based SDK usage (e.g., React/Vite frontends)
+    CORS_ALLOWED_ORIGINS: str = "*"  # Comma-separated origins or "*" for all
+    CORS_ALLOW_CREDENTIALS: bool = False  # Must be False when using "*" origins
+
+    def get_cors_origins(self) -> List[str]:
+        """Parse CORS allowed origins from comma-separated string.
+
+        Returns ["*"] for wildcard, or list of specific origins.
+        """
+        if self.CORS_ALLOWED_ORIGINS == "*":
+            return ["*"]
+        return [origin.strip() for origin in self.CORS_ALLOWED_ORIGINS.split(",") if origin.strip()]
+
     @field_validator("X402_BLACKLIST_IPS", "X402_WHITELIST_IPS", mode="before")
     @classmethod
     def empty_str_to_empty(cls, v: str) -> str:

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 # app/main.py
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from app.core.config import settings
 from app.core.version import VERSION
@@ -38,6 +39,18 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",  # Standard location for OpenAPI spec
     lifespan=lifespan
 )
+
+# Add CORS middleware for browser-based SDK usage
+# This must be added before other middleware
+cors_origins = settings.get_cors_origins()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=cors_origins,
+    allow_credentials=settings.CORS_ALLOW_CREDENTIALS,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+logger.info(f"CORS enabled for origins: {cors_origins}")
 
 # Add x402 payment middleware if enabled
 if settings.X402_ENABLED:
@@ -128,21 +141,6 @@ def read_root():
     return response_data
 
 # --- Placeholder for Future Enhancements ---
-
-# TODO: Add CORS middleware if the API needs to be accessed from browser frontends on different domains
-# from fastapi.middleware.cors import CORSMiddleware
-# origins = [
-#     "http://localhost",
-#     "http://localhost:8080",
-#     # Add your frontend domains here
-# ]
-# app.add_middleware(
-#     CORSMiddleware,
-#     allow_origins=origins,
-#     allow_credentials=True,
-#     allow_methods=["*"],
-#     allow_headers=["*"],
-# )
 
 # TODO: Add Security Dependencies when implementing Auth
 # (e.g., app.include_router(..., dependencies=[Depends(verify_api_key)]))

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,204 @@
+# tests/test_cors.py
+"""Tests for CORS middleware configuration."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+class TestCorsConfiguration:
+    """Test CORS settings parsing in config."""
+
+    def test_cors_origins_wildcard(self):
+        """Test wildcard CORS origin."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "*",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            assert settings.get_cors_origins() == ["*"]
+
+    def test_cors_origins_single(self):
+        """Test single CORS origin."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "https://app.datafund.io",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            assert settings.get_cors_origins() == ["https://app.datafund.io"]
+
+    def test_cors_origins_multiple(self):
+        """Test multiple comma-separated CORS origins."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "https://app.datafund.io,https://fairdrop.datafund.io,https://verity.datafund.io",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            origins = settings.get_cors_origins()
+            assert len(origins) == 3
+            assert "https://app.datafund.io" in origins
+            assert "https://fairdrop.datafund.io" in origins
+            assert "https://verity.datafund.io" in origins
+
+    def test_cors_origins_with_spaces(self):
+        """Test CORS origins with spaces are trimmed."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "https://app.datafund.io , https://fairdrop.datafund.io",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            origins = settings.get_cors_origins()
+            assert len(origins) == 2
+            assert "https://app.datafund.io" in origins
+            assert "https://fairdrop.datafund.io" in origins
+
+    def test_cors_credentials_default_false(self):
+        """Test CORS credentials defaults to false."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            assert settings.CORS_ALLOW_CREDENTIALS is False
+
+    def test_cors_credentials_can_be_enabled(self):
+        """Test CORS credentials can be enabled."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOW_CREDENTIALS": "true",
+        }, clear=False):
+            from app.core.config import Settings
+            settings = Settings()
+            assert settings.CORS_ALLOW_CREDENTIALS is True
+
+
+class TestCorsMiddleware:
+    """Test CORS middleware behavior with actual HTTP requests."""
+
+    @pytest.fixture
+    def client_with_cors(self):
+        """Create test client with CORS enabled."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "*",
+            "CORS_ALLOW_CREDENTIALS": "false",
+            "STAMP_POOL_ENABLED": "false",
+            "X402_ENABLED": "false",
+        }, clear=False):
+            # Need to reload modules to pick up new settings
+            import importlib
+            import app.core.config
+            importlib.reload(app.core.config)
+
+            # Now import main which will create app with new settings
+            import app.main
+            importlib.reload(app.main)
+
+            from fastapi.testclient import TestClient
+            return TestClient(app.main.app)
+
+    def test_cors_headers_on_get(self, client_with_cors):
+        """Test CORS headers are present on GET request."""
+        response = client_with_cors.get(
+            "/health",
+            headers={"Origin": "http://localhost:5173"}
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+
+    def test_cors_preflight_options(self, client_with_cors):
+        """Test CORS preflight OPTIONS request."""
+        response = client_with_cors.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+            }
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+        assert "GET" in response.headers.get("access-control-allow-methods", "")
+
+    def test_cors_preflight_post(self, client_with_cors):
+        """Test CORS preflight for POST request."""
+        response = client_with_cors.options(
+            "/api/v1/data/",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "content-type",
+            }
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+        assert "POST" in response.headers.get("access-control-allow-methods", "")
+
+    def test_cors_allows_all_headers(self, client_with_cors):
+        """Test CORS allows custom headers."""
+        response = client_with_cors.options(
+            "/health",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "GET",
+                "Access-Control-Request-Headers": "x-custom-header,authorization",
+            }
+        )
+        assert response.status_code == 200
+        # FastAPI CORS middleware reflects requested headers
+        allow_headers = response.headers.get("access-control-allow-headers", "")
+        assert "x-custom-header" in allow_headers.lower() or "*" in allow_headers
+
+
+class TestCorsWithSpecificOrigins:
+    """Test CORS with specific allowed origins."""
+
+    @pytest.fixture
+    def client_with_specific_origins(self):
+        """Create test client with specific CORS origins."""
+        with patch.dict("os.environ", {
+            "SWARM_BEE_API_URL": "https://api.gateway.ethswarm.org",
+            "CORS_ALLOWED_ORIGINS": "https://app.datafund.io,https://fairdrop.datafund.io",
+            "CORS_ALLOW_CREDENTIALS": "true",
+            "STAMP_POOL_ENABLED": "false",
+            "X402_ENABLED": "false",
+        }, clear=False):
+            import importlib
+            import app.core.config
+            importlib.reload(app.core.config)
+
+            import app.main
+            importlib.reload(app.main)
+
+            from fastapi.testclient import TestClient
+            return TestClient(app.main.app)
+
+    def test_allowed_origin_gets_cors_header(self, client_with_specific_origins):
+        """Test that allowed origin receives CORS header."""
+        response = client_with_specific_origins.get(
+            "/health",
+            headers={"Origin": "https://app.datafund.io"}
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "https://app.datafund.io"
+
+    def test_disallowed_origin_no_cors_header(self, client_with_specific_origins):
+        """Test that disallowed origin doesn't receive CORS header."""
+        response = client_with_specific_origins.get(
+            "/health",
+            headers={"Origin": "https://malicious-site.com"}
+        )
+        assert response.status_code == 200
+        # No CORS header for disallowed origin
+        assert response.headers.get("access-control-allow-origin") is None
+
+    def test_credentials_header_with_specific_origins(self, client_with_specific_origins):
+        """Test credentials header is present with specific origins."""
+        response = client_with_specific_origins.get(
+            "/health",
+            headers={"Origin": "https://app.datafund.io"}
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-credentials") == "true"


### PR DESCRIPTION
## Summary

- Add CORS middleware to enable browser-based SDK usage (React, Vite, etc.)
- Configurable via `CORS_ALLOWED_ORIGINS` and `CORS_ALLOW_CREDENTIALS` env vars
- Default: `*` (allow all origins) for development convenience

## Changes

- `app/core/config.py`: Add CORS settings with `get_cors_origins()` helper
- `app/main.py`: Enable CORSMiddleware, remove commented-out placeholder
- `.env.example`: Document CORS configuration options
- `.github/workflows/deploy.yml`: Add CORS env vars for staging deployment
- `CLAUDE.md`: Update documentation
- `tests/test_cors.py`: Add 13 tests for CORS config and middleware behavior

## Configuration

```bash
# Development (default - allow all)
CORS_ALLOWED_ORIGINS=*
CORS_ALLOW_CREDENTIALS=false

# Production (whitelist specific origins)
CORS_ALLOWED_ORIGINS=https://app.datafund.io,https://fairdrop.datafund.io
CORS_ALLOW_CREDENTIALS=true
```

## Test Plan

- [x] All 13 CORS tests pass
- [ ] Verify staging deployment works after merge
- [ ] Test from browser app (e.g., SDK demo) that CORS errors are resolved

Fixes #88