### PR TITLE
Fix CORS headers missing on 402 Payment Required responses

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,8 +40,15 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+# Add x402 payment middleware if enabled (must be added before CORS)
+if settings.X402_ENABLED:
+    from app.x402.middleware import X402Middleware
+    app.add_middleware(X402Middleware)
+    logger.info("x402 middleware enabled")
+
 # Add CORS middleware for browser-based SDK usage
-# This must be added before other middleware
+# IMPORTANT: Add CORS last so it wraps all other middleware.
+# This ensures CORS headers are added to ALL responses, including 402s from x402.
 cors_origins = settings.get_cors_origins()
 app.add_middleware(
     CORSMiddleware,
@@ -51,12 +58,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 logger.info(f"CORS enabled for origins: {cors_origins}")
-
-# Add x402 payment middleware if enabled
-if settings.X402_ENABLED:
-    from app.x402.middleware import X402Middleware
-    app.add_middleware(X402Middleware)
-    logger.info("x402 middleware enabled")
 
 # Include the API router(s)
 # The prefix ensures all routes start with /api/v1

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -166,3 +166,163 @@ class TestCorsMiddleware:
             )
             assert response.status_code == 200
             assert response.headers.get("access-control-allow-origin") == "*"
+
+
+class TestCorsOn402Responses:
+    """Test that CORS headers are present on 402 Payment Required responses.
+
+    This is critical for browser-based SDK usage - without CORS headers on 402s,
+    browsers block the response and clients can't see payment requirements.
+
+    Issue: https://github.com/datafund/swarm_connect/issues/90
+    """
+
+    def test_cors_on_402_response_middleware_order(self):
+        """Test that CORS middleware wraps x402 middleware correctly.
+
+        The middleware order in app.add_middleware() is LIFO for responses:
+        - Last added middleware is the outer wrapper
+        - CORS must be added LAST to wrap all responses including 402s
+
+        This test creates a minimal app to verify the middleware ordering pattern.
+        """
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
+
+        # Create a middleware that returns 402 (simulating x402)
+        class Mock402Middleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                if request.url.path == "/protected":
+                    return JSONResponse(
+                        status_code=402,
+                        content={"error": "Payment Required"}
+                    )
+                return await call_next(request)
+
+        # Create test app with correct middleware order
+        test_app = FastAPI()
+
+        @test_app.get("/")
+        def root():
+            return {"status": "ok"}
+
+        @test_app.post("/protected")
+        def protected():
+            return {"status": "ok"}
+
+        # Add middlewares in correct order: 402 middleware first, then CORS
+        # (CORS added last = outer wrapper = processes all responses)
+        test_app.add_middleware(Mock402Middleware)
+        test_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        client = TestClient(test_app)
+
+        # Test 402 response has CORS headers
+        response = client.post(
+            "/protected",
+            headers={"Origin": "http://localhost:5173"}
+        )
+        assert response.status_code == 402
+        assert response.headers.get("access-control-allow-origin") == "*", \
+            "402 responses must have CORS headers for browser SDK compatibility"
+
+    def test_cors_on_402_preflight_still_works(self):
+        """Test that preflight OPTIONS requests work for protected endpoints."""
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
+
+        class Mock402Middleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                # Don't block OPTIONS requests
+                if request.method == "OPTIONS":
+                    return await call_next(request)
+                if request.url.path == "/protected":
+                    return JSONResponse(
+                        status_code=402,
+                        content={"error": "Payment Required"}
+                    )
+                return await call_next(request)
+
+        test_app = FastAPI()
+
+        @test_app.post("/protected")
+        def protected():
+            return {"status": "ok"}
+
+        test_app.add_middleware(Mock402Middleware)
+        test_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        client = TestClient(test_app)
+
+        # Preflight should succeed
+        response = client.options(
+            "/protected",
+            headers={
+                "Origin": "http://localhost:5173",
+                "Access-Control-Request-Method": "POST",
+            }
+        )
+        assert response.status_code == 200
+        assert response.headers.get("access-control-allow-origin") == "*"
+
+    def test_wrong_middleware_order_breaks_cors_on_402(self):
+        """Demonstrate that wrong middleware order breaks CORS on 402 responses.
+
+        This test proves the bug described in issue #90:
+        If CORS is added BEFORE the 402 middleware, 402 responses won't have CORS headers.
+        """
+        from fastapi import FastAPI
+        from fastapi.middleware.cors import CORSMiddleware
+        from starlette.middleware.base import BaseHTTPMiddleware
+        from starlette.responses import JSONResponse
+
+        class Mock402Middleware(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                if request.url.path == "/protected":
+                    return JSONResponse(
+                        status_code=402,
+                        content={"error": "Payment Required"}
+                    )
+                return await call_next(request)
+
+        # Create app with WRONG order (CORS first, then 402 middleware)
+        test_app = FastAPI()
+
+        @test_app.post("/protected")
+        def protected():
+            return {"status": "ok"}
+
+        # WRONG ORDER: CORS added first, 402 middleware added second (outer)
+        test_app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["*"],
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+        test_app.add_middleware(Mock402Middleware)
+
+        client = TestClient(test_app)
+
+        # 402 response will NOT have CORS headers with wrong order
+        response = client.post(
+            "/protected",
+            headers={"Origin": "http://localhost:5173"}
+        )
+        assert response.status_code == 402
+        # This demonstrates the bug - no CORS header with wrong order
+        assert response.headers.get("access-control-allow-origin") is None, \
+            "Wrong middleware order: 402 response missing CORS headers"


### PR DESCRIPTION
## Summary

Fix middleware ordering so CORS headers are added to 402 responses from x402 middleware.

**Before:** x402 middleware was the outer wrapper, so 402 responses bypassed CORS.
**After:** CORS middleware is the outer wrapper, so ALL responses get CORS headers.

## Changes

- `app/main.py`: Swap middleware order - add x402 first, then CORS (CORS added last = outer wrapper)
- `tests/test_cors.py`: Add 3 tests demonstrating correct vs incorrect middleware ordering

## Test Plan

- [x] All 15 CORS tests pass (including 3 new tests for 402 responses)
- [ ] Verify on staging after merge: `curl -i -H 'Origin: http://localhost' POST .../api/v1/data/` returns 402 WITH CORS headers

Fixes #90