### PR TITLE
Add wallet and chequebook addresses to health endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -124,7 +124,9 @@ def read_root():
                 "ok": base_eth.get("ok"),
                 "is_critical": base_eth.get("is_critical"),
             },
-            "gnosis_wallet": {
+            "bee_gnosis_wallet": {
+                "wallet_address": gnosis.get("wallet_address"),
+                "chequebook_address": gnosis.get("chequebook_address"),
                 "can_accept": gnosis.get("can_accept"),
                 "xbzz_ok": gnosis.get("xbzz_ok"),
                 "xdai_ok": gnosis.get("xdai_ok"),

--- a/app/x402/preflight.py
+++ b/app/x402/preflight.py
@@ -14,7 +14,7 @@ import logging
 from typing import Dict, Any, List
 
 from app.core.config import settings
-from app.services.swarm_api import get_wallet_info, get_chequebook_balance
+from app.services.swarm_api import get_wallet_info, get_chequebook_info
 
 logger = logging.getLogger(__name__)
 
@@ -43,10 +43,12 @@ def check_xbzz_balance() -> Dict[str, Any]:
         - balance_plur: int - raw balance in PLUR
         - balance_bzz: float - balance in BZZ
         - threshold_bzz: float - warning threshold in BZZ
+        - wallet_address: str or None - Bee node wallet address on Gnosis
         - warning: str or None - warning message if below threshold
     """
     try:
         wallet_info = get_wallet_info()
+        wallet_address = wallet_info.get("walletAddress")
         balance_plur = int(wallet_info.get("bzzBalance", 0))
         balance_bzz = plur_to_bzz(balance_plur)
         threshold_bzz = settings.X402_XBZZ_WARN_THRESHOLD
@@ -57,7 +59,7 @@ def check_xbzz_balance() -> Dict[str, Any]:
         if not ok:
             warning = (
                 f"xBZZ balance ({balance_bzz:.4f} BZZ) is below threshold "
-                f"({threshold_bzz} BZZ). Top up your Gnosis wallet."
+                f"({threshold_bzz} BZZ). Top up Bee Gnosis wallet ({wallet_address})."
             )
             logger.warning(f"Pre-flight check: {warning}")
 
@@ -66,6 +68,7 @@ def check_xbzz_balance() -> Dict[str, Any]:
             "balance_plur": balance_plur,
             "balance_bzz": balance_bzz,
             "threshold_bzz": threshold_bzz,
+            "wallet_address": wallet_address,
             "warning": warning
         }
 
@@ -76,6 +79,7 @@ def check_xbzz_balance() -> Dict[str, Any]:
             "balance_plur": 0,
             "balance_bzz": 0.0,
             "threshold_bzz": settings.X402_XBZZ_WARN_THRESHOLD,
+            "wallet_address": None,
             "warning": f"Failed to fetch xBZZ balance: {str(e)}"
         }
 
@@ -92,10 +96,12 @@ def check_xdai_balance() -> Dict[str, Any]:
         - balance_wei: int - raw balance in wei
         - balance_xdai: float - balance in xDAI
         - threshold_xdai: float - warning threshold in xDAI
+        - wallet_address: str or None - Bee node wallet address on Gnosis
         - warning: str or None - warning message if below threshold
     """
     try:
         wallet_info = get_wallet_info()
+        wallet_address = wallet_info.get("walletAddress")
         balance_wei = int(wallet_info.get("nativeTokenBalance", 0))
         balance_xdai = wei_to_xdai(balance_wei)
         threshold_xdai = settings.X402_XDAI_WARN_THRESHOLD
@@ -106,7 +112,7 @@ def check_xdai_balance() -> Dict[str, Any]:
         if not ok:
             warning = (
                 f"xDAI balance ({balance_xdai:.4f} xDAI) is below threshold "
-                f"({threshold_xdai} xDAI). Top up your Gnosis wallet for gas."
+                f"({threshold_xdai} xDAI). Top up Bee Gnosis wallet ({wallet_address}) for gas."
             )
             logger.warning(f"Pre-flight check: {warning}")
 
@@ -115,6 +121,7 @@ def check_xdai_balance() -> Dict[str, Any]:
             "balance_wei": balance_wei,
             "balance_xdai": balance_xdai,
             "threshold_xdai": threshold_xdai,
+            "wallet_address": wallet_address,
             "warning": warning
         }
 
@@ -125,6 +132,7 @@ def check_xdai_balance() -> Dict[str, Any]:
             "balance_wei": 0,
             "balance_xdai": 0.0,
             "threshold_xdai": settings.X402_XDAI_WARN_THRESHOLD,
+            "wallet_address": None,
             "warning": f"Failed to fetch xDAI balance: {str(e)}"
         }
 
@@ -143,12 +151,14 @@ def check_chequebook_balance() -> Dict[str, Any]:
         - total_balance_plur: int - total balance in PLUR
         - total_balance_bzz: float - total balance in BZZ
         - threshold_bzz: float - warning threshold in BZZ
+        - chequebook_address: str or None - chequebook contract address
         - warning: str or None - warning message if below threshold
     """
     try:
-        chequebook_info = get_chequebook_balance()
-        available_plur = int(chequebook_info.get("availableBalance", 0))
-        total_plur = int(chequebook_info.get("totalBalance", 0))
+        chequebook_data = get_chequebook_info()
+        chequebook_address = chequebook_data.get("chequebookAddress")
+        available_plur = int(chequebook_data.get("availableBalance", 0))
+        total_plur = int(chequebook_data.get("totalBalance", 0))
         available_bzz = plur_to_bzz(available_plur)
         total_bzz = plur_to_bzz(total_plur)
         threshold_bzz = settings.X402_CHEQUEBOOK_WARN_THRESHOLD
@@ -159,7 +169,7 @@ def check_chequebook_balance() -> Dict[str, Any]:
         if not ok:
             warning = (
                 f"Chequebook available balance ({available_bzz:.4f} BZZ) is below threshold "
-                f"({threshold_bzz} BZZ). Top up your chequebook for bandwidth payments."
+                f"({threshold_bzz} BZZ). Top up chequebook ({chequebook_address}) for bandwidth payments."
             )
             logger.warning(f"Pre-flight check: {warning}")
 
@@ -170,6 +180,7 @@ def check_chequebook_balance() -> Dict[str, Any]:
             "total_balance_plur": total_plur,
             "total_balance_bzz": total_bzz,
             "threshold_bzz": threshold_bzz,
+            "chequebook_address": chequebook_address,
             "warning": warning
         }
 
@@ -182,6 +193,7 @@ def check_chequebook_balance() -> Dict[str, Any]:
             "total_balance_plur": 0,
             "total_balance_bzz": 0.0,
             "threshold_bzz": settings.X402_CHEQUEBOOK_WARN_THRESHOLD,
+            "chequebook_address": None,
             "warning": f"Failed to fetch chequebook balance: {str(e)}"
         }
 
@@ -248,6 +260,8 @@ def check_preflight_balances() -> Dict[str, Any]:
 
     return {
         "can_accept": can_accept,
+        "wallet_address": xbzz_result.get("wallet_address"),
+        "chequebook_address": chequebook_result.get("chequebook_address"),
         "xbzz_ok": xbzz_ok,
         "xdai_ok": xdai_ok,
         "chequebook_ok": chequebook_ok,

--- a/docs/x402-operator-guide.md
+++ b/docs/x402-operator-guide.md
@@ -286,7 +286,9 @@ curl http://localhost:8000/health | jq .
       "ok": true,
       "is_critical": false
     },
-    "gnosis_wallet": {
+    "bee_gnosis_wallet": {
+      "wallet_address": "0xBeeNodeWallet...",
+      "chequebook_address": "0xChequebook...",
       "can_accept": true,
       "xbzz_ok": true,
       "xdai_ok": true,
@@ -369,7 +371,7 @@ Since there's no automatic bridging, you need to manually manage:
 Gateway wallet is below critical thresholds:
 
 1. Check health endpoint: `curl http://localhost:8000/health | jq .`
-2. Look at `x402.base_wallet.is_critical` and `x402.gnosis_wallet.can_accept`
+2. Look at `x402.base_wallet.is_critical` and `x402.bee_gnosis_wallet.can_accept`
 3. If Base ETH is critical: Top up ETH on Base Sepolia
 4. If Gnosis balances are low: Top up xBZZ or xDAI on Gnosis
 

--- a/tests/test_x402_integration.py
+++ b/tests/test_x402_integration.py
@@ -748,6 +748,8 @@ class TestHealthEndpointWithX402:
 
         mock_preflight.return_value = {
             "can_accept": True,
+            "wallet_address": "0xBeeWallet123",
+            "chequebook_address": "0xCheque123",
             "xbzz_ok": True,
             "xdai_ok": True,
             "chequebook_ok": True,
@@ -763,7 +765,7 @@ class TestHealthEndpointWithX402:
         assert "x402" in response
         assert response["x402"]["enabled"] is True
         assert response["x402"]["base_wallet"]["ok"] is True
-        assert response["x402"]["gnosis_wallet"]["can_accept"] is True
+        assert response["x402"]["bee_gnosis_wallet"]["can_accept"] is True
         assert len(response["x402"]["warnings"]) == 0
         assert len(response["x402"]["errors"]) == 0
 
@@ -788,6 +790,8 @@ class TestHealthEndpointWithX402:
 
         mock_preflight.return_value = {
             "can_accept": True,
+            "wallet_address": "0xBeeWallet123",
+            "chequebook_address": "0xCheque123",
             "xbzz_ok": True,
             "xdai_ok": True,
             "chequebook_ok": True,
@@ -825,6 +829,8 @@ class TestHealthEndpointWithX402:
 
         mock_preflight.return_value = {
             "can_accept": True,
+            "wallet_address": "0xBeeWallet123",
+            "chequebook_address": "0xCheque123",
             "xbzz_ok": True,
             "xdai_ok": True,
             "chequebook_ok": True,
@@ -864,6 +870,8 @@ class TestHealthEndpointWithX402:
 
         mock_preflight.return_value = {
             "can_accept": True,
+            "wallet_address": "0xBeeWallet123",
+            "chequebook_address": "0xCheque123",
             "xbzz_ok": True,
             "xdai_ok": True,
             "chequebook_ok": True,

--- a/tests/test_x402_preflight.py
+++ b/tests/test_x402_preflight.py
@@ -167,12 +167,13 @@ class TestCheckXDAIBalance:
 class TestCheckChequebookBalance:
     """Test chequebook balance checks."""
 
-    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.get_chequebook_info")
     @patch("app.x402.preflight.settings")
     def test_chequebook_above_threshold(self, mock_settings, mock_get_chequebook):
         """Chequebook balance above threshold returns ok=True."""
         mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
         mock_get_chequebook.return_value = {
+            "chequebookAddress": "0xcheque123",
             "availableBalance": str(10 * PLUR_PER_BZZ),  # 10 BZZ
             "totalBalance": str(15 * PLUR_PER_BZZ)  # 15 BZZ
         }
@@ -185,12 +186,13 @@ class TestCheckChequebookBalance:
         assert result["threshold_bzz"] == 5.0
         assert result["warning"] is None
 
-    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.get_chequebook_info")
     @patch("app.x402.preflight.settings")
     def test_chequebook_below_threshold(self, mock_settings, mock_get_chequebook):
         """Chequebook balance below threshold returns ok=False with warning."""
         mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
         mock_get_chequebook.return_value = {
+            "chequebookAddress": "0xcheque123",
             "availableBalance": str(2 * PLUR_PER_BZZ),  # 2 BZZ
             "totalBalance": str(5 * PLUR_PER_BZZ)  # 5 BZZ
         }
@@ -202,7 +204,7 @@ class TestCheckChequebookBalance:
         assert "below threshold" in result["warning"]
         assert "bandwidth" in result["warning"].lower()
 
-    @patch("app.x402.preflight.get_chequebook_balance")
+    @patch("app.x402.preflight.get_chequebook_info")
     @patch("app.x402.preflight.settings")
     def test_chequebook_api_error(self, mock_settings, mock_get_chequebook):
         """API error returns ok=False with error message."""
@@ -229,6 +231,7 @@ class TestCheckPreflightBalances:
             "balance_plur": 20 * PLUR_PER_BZZ,
             "balance_bzz": 20.0,
             "threshold_bzz": 10.0,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_xdai.return_value = {
@@ -236,6 +239,7 @@ class TestCheckPreflightBalances:
             "balance_wei": int(1.0 * WEI_PER_XDAI),
             "balance_xdai": 1.0,
             "threshold_xdai": 0.5,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_chequebook.return_value = {
@@ -245,6 +249,7 @@ class TestCheckPreflightBalances:
             "total_balance_plur": 15 * PLUR_PER_BZZ,
             "total_balance_bzz": 15.0,
             "threshold_bzz": 5.0,
+            "chequebook_address": "0xcheque123",
             "warning": None
         }
 
@@ -267,6 +272,7 @@ class TestCheckPreflightBalances:
             "balance_plur": 5 * PLUR_PER_BZZ,
             "balance_bzz": 5.0,
             "threshold_bzz": 10.0,
+            "wallet_address": "0xwallet123",
             "warning": "xBZZ balance below threshold"
         }
         mock_xdai.return_value = {
@@ -274,6 +280,7 @@ class TestCheckPreflightBalances:
             "balance_wei": int(1.0 * WEI_PER_XDAI),
             "balance_xdai": 1.0,
             "threshold_xdai": 0.5,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_chequebook.return_value = {
@@ -283,6 +290,7 @@ class TestCheckPreflightBalances:
             "total_balance_plur": 15 * PLUR_PER_BZZ,
             "total_balance_bzz": 15.0,
             "threshold_bzz": 5.0,
+            "chequebook_address": "0xcheque123",
             "warning": None
         }
 
@@ -304,6 +312,7 @@ class TestCheckPreflightBalances:
             "balance_plur": 0,
             "balance_bzz": 0.0,
             "threshold_bzz": 10.0,
+            "wallet_address": None,
             "warning": "Failed to fetch xBZZ balance: Connection refused"
         }
         mock_xdai.return_value = {
@@ -311,6 +320,7 @@ class TestCheckPreflightBalances:
             "balance_wei": int(1.0 * WEI_PER_XDAI),
             "balance_xdai": 1.0,
             "threshold_xdai": 0.5,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_chequebook.return_value = {
@@ -320,6 +330,7 @@ class TestCheckPreflightBalances:
             "total_balance_plur": 15 * PLUR_PER_BZZ,
             "total_balance_bzz": 15.0,
             "threshold_bzz": 5.0,
+            "chequebook_address": "0xcheque123",
             "warning": None
         }
 
@@ -340,6 +351,7 @@ class TestCheckPreflightBalances:
             "balance_plur": 20 * PLUR_PER_BZZ,
             "balance_bzz": 20.0,
             "threshold_bzz": 10.0,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_xdai.return_value = {
@@ -347,6 +359,7 @@ class TestCheckPreflightBalances:
             "balance_wei": int(1.0 * WEI_PER_XDAI),
             "balance_xdai": 1.0,
             "threshold_xdai": 0.5,
+            "wallet_address": "0xwallet123",
             "warning": None
         }
         mock_chequebook.return_value = {
@@ -356,6 +369,7 @@ class TestCheckPreflightBalances:
             "total_balance_plur": 15 * PLUR_PER_BZZ,
             "total_balance_bzz": 15.0,
             "threshold_bzz": 5.0,
+            "chequebook_address": "0xcheque123",
             "warning": None
         }
 
@@ -387,6 +401,7 @@ class TestCheckPreflightBalances:
             "balance_plur": 5 * PLUR_PER_BZZ,
             "balance_bzz": 5.0,
             "threshold_bzz": 10.0,
+            "wallet_address": "0xwallet123",
             "warning": "xBZZ below threshold"
         }
         mock_xdai.return_value = {
@@ -394,6 +409,7 @@ class TestCheckPreflightBalances:
             "balance_wei": int(0.1 * WEI_PER_XDAI),
             "balance_xdai": 0.1,
             "threshold_xdai": 0.5,
+            "wallet_address": "0xwallet123",
             "warning": "xDAI below threshold"
         }
         mock_chequebook.return_value = {
@@ -403,6 +419,7 @@ class TestCheckPreflightBalances:
             "total_balance_plur": 5 * PLUR_PER_BZZ,
             "total_balance_bzz": 5.0,
             "threshold_bzz": 5.0,
+            "chequebook_address": "0xcheque123",
             "warning": "Chequebook below threshold"
         }
 


### PR DESCRIPTION
## Summary

- Rename `gnosis_wallet` to `bee_gnosis_wallet` in health endpoint response
- Add `wallet_address` and `chequebook_address` fields to the response
- Include addresses in warning messages so operators know where to send funds
- Update docs and tests

Closes #108