### PR TITLE
Fix pool importing all Bee node stamps — add state persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,7 @@ SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
 # STAMP_POOL_TOPUP_HOURS=168                  # How much TTL to add when topping up (1 week)
 # STAMP_POOL_LOW_RESERVE_THRESHOLD=1          # Alert when reserve drops to this level
 # STAMP_POOL_DEFAULT_DURATION_HOURS=168       # Duration for newly purchased pool stamps (1 week)
+# STAMP_POOL_STATE_FILE=data/pool_state.json  # State file for pool persistence across restarts
 #
 # Note: Pool will auto-purchase stamps when reserve is low.
 # Ensure Bee node wallet has sufficient xBZZ and xDAI.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
       - name: write env file for dev
         if: github.ref == 'refs/heads/dev'
         run: |
+          mkdir -p /opt/swarm_connect_dev_data
           cat > /opt/swarm_connect_dev.env << 'EOF'
           X402_ENABLED=${{ vars.X402_ENABLED || 'false' }}
           X402_PAY_TO_ADDRESS=${{ vars.X402_PAY_TO_ADDRESS || '' }}
@@ -51,6 +52,7 @@ jobs:
           STAMP_POOL_MIN_TTL_HOURS=${{ vars.STAMP_POOL_MIN_TTL_HOURS || '24' }}
           STAMP_POOL_TOPUP_HOURS=${{ vars.STAMP_POOL_TOPUP_HOURS || '168' }}
           STAMP_POOL_DEFAULT_DURATION_HOURS=${{ vars.STAMP_POOL_DEFAULT_DURATION_HOURS || '168' }}
+          STAMP_POOL_STATE_FILE=${{ vars.STAMP_POOL_STATE_FILE || 'data/pool_state.json' }}
           NOTARY_ENABLED=${{ vars.NOTARY_ENABLED || 'false' }}
           NOTARY_PRIVATE_KEY=${{ secrets.NOTARY_PRIVATE_KEY || '' }}
           CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS || '*' }}
@@ -64,6 +66,7 @@ jobs:
       - name: write env file for main
         if: github.ref == 'refs/heads/main'
         run: |
+          mkdir -p /opt/swarm_connect_data
           cat > /opt/swarm_connect.env << 'EOF'
           X402_ENABLED=${{ vars.X402_ENABLED || 'false' }}
           X402_PAY_TO_ADDRESS=${{ vars.X402_PAY_TO_ADDRESS || '' }}
@@ -78,6 +81,7 @@ jobs:
           STAMP_POOL_MIN_TTL_HOURS=${{ vars.STAMP_POOL_MIN_TTL_HOURS || '24' }}
           STAMP_POOL_TOPUP_HOURS=${{ vars.STAMP_POOL_TOPUP_HOURS || '168' }}
           STAMP_POOL_DEFAULT_DURATION_HOURS=${{ vars.STAMP_POOL_DEFAULT_DURATION_HOURS || '168' }}
+          STAMP_POOL_STATE_FILE=${{ vars.STAMP_POOL_STATE_FILE || 'data/pool_state.json' }}
           NOTARY_ENABLED=${{ vars.NOTARY_ENABLED || 'false' }}
           NOTARY_PRIVATE_KEY=${{ secrets.NOTARY_PRIVATE_KEY || '' }}
           CORS_ALLOWED_ORIGINS=${{ vars.CORS_ALLOWED_ORIGINS || '*' }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ venv/
 *.sqlite3
 *.db
 VERSION
+data/

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -80,6 +80,9 @@ class Settings(BaseSettings):
     # immediately (async) when a stamp is released from the pool
     STAMP_POOL_IMMEDIATE_REPLENISH: bool = True
 
+    # State persistence: file path for persisting pool state across restarts
+    STAMP_POOL_STATE_FILE: str = "data/pool_state.json"
+
     # === Notary/Provenance Signing Settings ===
     # The notary feature allows the gateway to sign documents with an authoritative timestamp.
     # This provides proof that a document existed at a specific time, signed by the gateway.

--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -15,11 +15,13 @@ Architecture:
 See GitHub Issue #63 for full specification.
 """
 import asyncio
+import json
 import logging
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 from threading import Lock
 
 from app.core.config import settings
@@ -72,7 +74,7 @@ class StampPoolManager:
     approaching expiration.
     """
 
-    def __init__(self):
+    def __init__(self, state_file: Optional[str] = None):
         self._pool: Dict[str, PoolStamp] = {}  # batch_id -> PoolStamp
         self._lock = Lock()
         self._running = False
@@ -80,6 +82,7 @@ class StampPoolManager:
         self._last_check: Optional[datetime] = None
         self._errors: List[str] = []
         self._pending_replenishments: Dict[int, int] = {}  # depth -> count of pending purchases
+        self._state_file = state_file  # Allow override for testing
 
     @property
     def is_enabled(self) -> bool:
@@ -89,6 +92,51 @@ class StampPoolManager:
     def get_reserve_config(self) -> Dict[int, int]:
         """Get the configured reserve levels by depth."""
         return settings.get_stamp_pool_reserve_config()
+
+    def _get_state_file_path(self) -> str:
+        """Get the state file path, using override or settings."""
+        return self._state_file or settings.STAMP_POOL_STATE_FILE
+
+    def _save_state(self):
+        """Persist current pool batch IDs to state file."""
+        state_file = self._get_state_file_path()
+        try:
+            state_dir = os.path.dirname(state_file)
+            if state_dir:
+                os.makedirs(state_dir, exist_ok=True)
+            batch_ids = list(self._pool.keys())
+            with open(state_file, 'w') as f:
+                json.dump(batch_ids, f)
+            logger.debug(f"Saved pool state: {len(batch_ids)} stamps to {state_file}")
+        except Exception as e:
+            logger.error(f"Failed to save pool state to {state_file}: {e}")
+
+    def _load_state(self) -> Set[str]:
+        """Load pool batch IDs from state file.
+
+        Returns:
+            Set of batch IDs that were previously in the pool.
+            Returns empty set if file is missing or corrupt.
+        """
+        state_file = self._get_state_file_path()
+        try:
+            with open(state_file, 'r') as f:
+                batch_ids = json.load(f)
+            if isinstance(batch_ids, list):
+                logger.info(f"Loaded pool state: {len(batch_ids)} stamps from {state_file}")
+                return set(batch_ids)
+            else:
+                logger.warning(f"Invalid pool state format in {state_file}, treating as first run")
+                return set()
+        except FileNotFoundError:
+            logger.info(f"No pool state file at {state_file}, treating as first run")
+            return set()
+        except (json.JSONDecodeError, ValueError) as e:
+            logger.warning(f"Corrupt pool state file {state_file}: {e}, treating as first run")
+            return set()
+        except Exception as e:
+            logger.warning(f"Error loading pool state from {state_file}: {e}, treating as first run")
+            return set()
 
     def get_status(self) -> PoolStatus:
         """Get current pool status."""
@@ -200,6 +248,7 @@ class StampPoolManager:
             # Remove from pool (we no longer manage it)
             del self._pool[batch_id]
 
+            self._save_state()
             return stamp
 
     def trigger_replenishment_if_needed(self, depth: int) -> bool:
@@ -309,53 +358,57 @@ class StampPoolManager:
             )
             self._pool[batch_id] = stamp
             logger.info(f"Added stamp {batch_id[:16]}... to pool (depth={depth})")
+            self._save_state()
             return stamp
 
     async def sync_from_bee_node(self) -> int:
         """
-        Sync pool with stamps from the Bee node.
+        Sync pool with stamps from the Bee node using persisted state.
 
-        This finds existing stamps that match pool criteria and adds them.
-        Useful for initial population or recovery.
+        Only re-imports stamps whose batch IDs are in the state file.
+        On first run (no state file), imports nothing — the purchase logic
+        will fill the pool to the configured reserve target.
 
         Returns:
             Number of stamps synced
         """
         try:
+            known_ids = self._load_state()
+
+            # First run: no state file means empty pool, let purchase logic fill it
+            if not known_ids:
+                logger.info("No known stamps in state file, pool will be filled by purchase logic")
+                return 0
+
             all_stamps = swarm_api.get_all_stamps_processed()
+            stamp_map = {s.get("batchID"): s for s in all_stamps}
             synced_count = 0
-            reserve_config = self.get_reserve_config()
-            target_depths = set(reserve_config.keys())
+            valid_ids = set()
 
             with self._lock:
-                for stamp_data in all_stamps:
-                    batch_id = stamp_data.get("batchID")
-                    depth = stamp_data.get("depth")
-                    is_local = stamp_data.get("local", False)
+                for batch_id in known_ids:
+                    # Skip if already in pool
+                    if batch_id in self._pool:
+                        valid_ids.add(batch_id)
+                        continue
+
+                    stamp_data = stamp_map.get(batch_id)
+                    if not stamp_data:
+                        # Stamp no longer exists on Bee node (expired/removed)
+                        logger.info(f"Known stamp {batch_id[:16]}... no longer on Bee node, removing from state")
+                        continue
+
                     usable = stamp_data.get("usable", False)
                     ttl = stamp_data.get("batchTTL", 0)
 
-                    # Skip if already in pool
-                    if batch_id in self._pool:
+                    if not usable or ttl <= 0:
+                        logger.info(f"Known stamp {batch_id[:16]}... is expired/unusable, removing from state")
                         continue
 
-                    # Only add local, usable stamps with matching depth
-                    if not is_local or not usable:
-                        continue
-
-                    if depth not in target_depths:
-                        continue
-
-                    # Skip stamps with low TTL
-                    min_ttl_seconds = settings.STAMP_POOL_MIN_TTL_HOURS * 3600
-                    if ttl < min_ttl_seconds:
-                        continue
-
-                    # Check if pool label suggests it's a pool stamp
-                    label = stamp_data.get("label", "")
-
-                    # Add to pool
+                    # Re-import this known stamp
+                    depth = stamp_data.get("depth")
                     amount = int(stamp_data.get("amount", 0))
+                    label = stamp_data.get("label", "")
                     stamp = PoolStamp(
                         batch_id=batch_id,
                         depth=depth,
@@ -366,8 +419,13 @@ class StampPoolManager:
                         label=label or f"synced-{depth}"
                     )
                     self._pool[batch_id] = stamp
+                    valid_ids.add(batch_id)
                     synced_count += 1
-                    logger.info(f"Synced existing stamp {batch_id[:16]}... to pool (depth={depth}, ttl={ttl}s)")
+                    logger.info(f"Synced known stamp {batch_id[:16]}... to pool (depth={depth}, ttl={ttl}s)")
+
+            # Save cleaned state (only stamps that are still valid)
+            if valid_ids != known_ids:
+                self._save_state()
 
             return synced_count
 
@@ -562,6 +620,9 @@ class StampPoolManager:
 
                 for batch_id in to_remove:
                     del self._pool[batch_id]
+
+                if to_remove:
+                    self._save_state()
 
         except Exception as e:
             logger.warning(f"Error updating stamp TTLs: {e}")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - /opt/swarm_connect.env
     environment:
       - SWARM_BEE_API_URL=http://192.168.45.30:1633
+    volumes:
+      - /opt/swarm_connect_data:/app/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]
@@ -25,6 +27,8 @@ services:
       - /opt/swarm_connect_dev.env
     environment:
       - SWARM_BEE_API_URL=http://192.168.45.30:1633
+    volumes:
+      - /opt/swarm_connect_dev_data:/app/data
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/"]

--- a/tests/test_stamp_pool.py
+++ b/tests/test_stamp_pool.py
@@ -2,9 +2,12 @@
 """
 Unit tests for the Stamp Pool feature.
 """
+import json
+import os
+import tempfile
 import pytest
 from datetime import datetime, timezone
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 from fastapi.testclient import TestClient
 
 from app.services.stamp_pool import (
@@ -489,3 +492,396 @@ class TestLowReserveWarning:
                 status = manager.get_status()
                 # All targets met, no warning
                 assert status.low_reserve_warning is False
+
+
+class TestPoolStatePersistence:
+    """Test pool state persistence (save/load)."""
+
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Create a temporary state file path."""
+        return str(tmp_path / "pool_state.json")
+
+    @pytest.fixture
+    def manager(self, state_file):
+        """Create a StampPoolManager with a temp state file."""
+        return StampPoolManager(state_file=state_file)
+
+    def test_save_and_load_state(self, state_file):
+        """Test round-trip: add stamps, save, create new manager, load."""
+        manager1 = StampPoolManager(state_file=state_file)
+        manager1.add_stamp_to_pool("batch_aaa", 17, 1000000, 604800)
+        manager1.add_stamp_to_pool("batch_bbb", 20, 2000000, 604800)
+
+        # Create a new manager with the same state file
+        manager2 = StampPoolManager(state_file=state_file)
+        loaded_ids = manager2._load_state()
+
+        assert loaded_ids == {"batch_aaa", "batch_bbb"}
+
+    def test_load_state_missing_file(self, tmp_path):
+        """Test loading state when file doesn't exist returns empty set."""
+        manager = StampPoolManager(state_file=str(tmp_path / "nonexistent.json"))
+        loaded = manager._load_state()
+        assert loaded == set()
+
+    def test_load_state_corrupt_file(self, state_file):
+        """Test loading corrupt state file returns empty set and logs warning."""
+        with open(state_file, 'w') as f:
+            f.write("not valid json {{{")
+
+        manager = StampPoolManager(state_file=state_file)
+        loaded = manager._load_state()
+        assert loaded == set()
+
+    def test_load_state_wrong_type(self, state_file):
+        """Test loading state file with wrong JSON type returns empty set."""
+        with open(state_file, 'w') as f:
+            json.dump({"not": "a list"}, f)
+
+        manager = StampPoolManager(state_file=state_file)
+        loaded = manager._load_state()
+        assert loaded == set()
+
+    def test_add_stamp_saves_state(self, manager, state_file):
+        """Test that adding a stamp to pool persists it."""
+        manager.add_stamp_to_pool("batch_123", 17, 1000000, 604800)
+
+        # Verify state file was written
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert "batch_123" in saved
+
+    def test_release_stamp_saves_state(self, manager, state_file):
+        """Test that releasing a stamp removes it from state file."""
+        manager.add_stamp_to_pool("batch_123", 17, 1000000, 604800)
+        manager.release_stamp("batch_123")
+
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert "batch_123" not in saved
+
+    @pytest.mark.asyncio
+    async def test_expired_stamp_removed_from_state(self, manager, state_file):
+        """Test that TTL cleanup removes expired stamps from state file."""
+        manager.add_stamp_to_pool("batch_exp", 17, 1000000, 604800)
+
+        # Verify stamp is in state file
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert "batch_exp" in saved
+
+        # Mock Bee node returning stamp as expired
+        mock_stamps = [{"batchID": "batch_exp", "batchTTL": 0, "usable": False}]
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=mock_stamps):
+            await manager._update_stamp_ttls()
+
+        # Stamp should be removed from pool and state file
+        assert "batch_exp" not in manager._pool
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert "batch_exp" not in saved
+
+    def test_save_state_creates_directory(self, tmp_path):
+        """Test that _save_state creates the data directory if missing."""
+        nested_path = str(tmp_path / "subdir" / "pool_state.json")
+        manager = StampPoolManager(state_file=nested_path)
+        manager.add_stamp_to_pool("batch_dir", 17, 1000000, 604800)
+
+        assert os.path.exists(nested_path)
+
+
+class TestPoolSyncBehavior:
+    """Test that sync_from_bee_node only imports known stamps."""
+
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Create a temporary state file path."""
+        return str(tmp_path / "pool_state.json")
+
+    @pytest.mark.asyncio
+    async def test_sync_only_imports_known_stamps(self, state_file):
+        """Bee has 50 stamps, state has 2 IDs -> only 2 imported."""
+        # Write state file with 2 known IDs
+        with open(state_file, 'w') as f:
+            json.dump(["known_aaa", "known_bbb"], f)
+
+        # Mock Bee node returning 50 stamps
+        bee_stamps = []
+        for i in range(50):
+            bee_stamps.append({
+                "batchID": f"stamp_{i:03d}",
+                "depth": 17,
+                "local": True,
+                "usable": True,
+                "batchTTL": 604800,
+                "amount": "1000000",
+                "label": ""
+            })
+        # Add the known stamps to the Bee response
+        bee_stamps.append({"batchID": "known_aaa", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""})
+        bee_stamps.append({"batchID": "known_bbb", "depth": 20, "local": True, "usable": True, "batchTTL": 604800, "amount": "2000000", "label": ""})
+
+        manager = StampPoolManager(state_file=state_file)
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+            synced = await manager.sync_from_bee_node()
+
+        assert synced == 2
+        assert len(manager._pool) == 2
+        assert "known_aaa" in manager._pool
+        assert "known_bbb" in manager._pool
+
+    @pytest.mark.asyncio
+    async def test_sync_first_run_imports_nothing(self, state_file):
+        """No state file -> sync returns 0, pool empty."""
+        manager = StampPoolManager(state_file=state_file)
+
+        bee_stamps = [
+            {"batchID": f"stamp_{i}", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""}
+            for i in range(10)
+        ]
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+            synced = await manager.sync_from_bee_node()
+
+        assert synced == 0
+        assert len(manager._pool) == 0
+
+    @pytest.mark.asyncio
+    async def test_sync_skips_expired_known_stamps(self, state_file):
+        """Stamp in state but expired on Bee -> not imported, removed from state."""
+        with open(state_file, 'w') as f:
+            json.dump(["expired_stamp", "valid_stamp"], f)
+
+        bee_stamps = [
+            {"batchID": "expired_stamp", "depth": 17, "local": True, "usable": False, "batchTTL": 0, "amount": "1000000", "label": ""},
+            {"batchID": "valid_stamp", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+        ]
+
+        manager = StampPoolManager(state_file=state_file)
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+            synced = await manager.sync_from_bee_node()
+
+        assert synced == 1
+        assert "expired_stamp" not in manager._pool
+        assert "valid_stamp" in manager._pool
+
+        # State file should be updated (expired stamp removed)
+        with open(state_file, 'r') as f:
+            saved = json.load(f)
+        assert "expired_stamp" not in saved
+        assert "valid_stamp" in saved
+
+    @pytest.mark.asyncio
+    async def test_sync_skips_unusable_known_stamps(self, state_file):
+        """Stamp in state but unusable -> not imported."""
+        with open(state_file, 'w') as f:
+            json.dump(["unusable_stamp"], f)
+
+        bee_stamps = [
+            {"batchID": "unusable_stamp", "depth": 17, "local": True, "usable": False, "batchTTL": 100, "amount": "1000000", "label": ""},
+        ]
+
+        manager = StampPoolManager(state_file=state_file)
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+            synced = await manager.sync_from_bee_node()
+
+        assert synced == 0
+        assert "unusable_stamp" not in manager._pool
+
+    @pytest.mark.asyncio
+    async def test_sync_skips_missing_known_stamps(self, state_file):
+        """Stamp in state but not on Bee node -> not imported."""
+        with open(state_file, 'w') as f:
+            json.dump(["gone_stamp"], f)
+
+        bee_stamps = []  # Bee has no stamps
+
+        manager = StampPoolManager(state_file=state_file)
+        with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+            synced = await manager.sync_from_bee_node()
+
+        assert synced == 0
+        assert len(manager._pool) == 0
+
+
+class TestPoolResizeBehavior:
+    """Test pool purchasing behavior on first run and restarts."""
+
+    @pytest.fixture
+    def state_file(self, tmp_path):
+        """Create a temporary state file path."""
+        return str(tmp_path / "pool_state.json")
+
+    @pytest.mark.asyncio
+    async def test_pool_purchases_to_target_on_first_run(self, state_file):
+        """Empty state -> purchases exactly reserve count."""
+        manager = StampPoolManager(state_file=state_file)
+
+        purchase_count = 0
+
+        async def mock_purchase(depth):
+            nonlocal purchase_count
+            purchase_count += 1
+            batch_id = f"purchased_{purchase_count}"
+            manager.add_stamp_to_pool(batch_id, depth, 1000000, 604800)
+            return batch_id
+
+        with patch.object(manager, '_purchase_stamp', side_effect=mock_purchase):
+            with patch.object(manager, 'get_reserve_config', return_value={17: 2}):
+                with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=[]):
+                    with patch.object(manager, '_update_stamp_ttls', new_callable=AsyncMock):
+                        with patch.object(manager, '_get_stamp_ttl', return_value=604800):
+                            with patch('app.services.stamp_pool.settings') as mock_settings:
+                                mock_settings.STAMP_POOL_ENABLED = True
+                                mock_settings.STAMP_POOL_MIN_TTL_HOURS = 24
+
+                                await manager.check_and_replenish()
+
+        assert purchase_count == 2
+        assert len(manager._pool) == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_does_not_over_purchase(self, state_file):
+        """Restart with full state -> no new purchases."""
+        # Pre-populate state file
+        with open(state_file, 'w') as f:
+            json.dump(["existing_1", "existing_2"], f)
+
+        bee_stamps = [
+            {"batchID": "existing_1", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+            {"batchID": "existing_2", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+        ]
+
+        manager = StampPoolManager(state_file=state_file)
+        purchase_count = 0
+
+        async def mock_purchase(depth):
+            nonlocal purchase_count
+            purchase_count += 1
+            return f"new_{purchase_count}"
+
+        with patch.object(manager, '_purchase_stamp', side_effect=mock_purchase):
+            with patch.object(manager, 'get_reserve_config', return_value={17: 2}):
+                with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+                    with patch.object(manager, '_update_stamp_ttls', new_callable=AsyncMock):
+                        with patch.object(manager, '_get_stamp_ttl', return_value=604800):
+                            with patch('app.services.stamp_pool.settings') as mock_settings:
+                                mock_settings.STAMP_POOL_ENABLED = True
+                                mock_settings.STAMP_POOL_MIN_TTL_HOURS = 24
+
+                                await manager.check_and_replenish()
+
+        assert purchase_count == 0
+        assert len(manager._pool) == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_fills_gap_after_release(self, state_file):
+        """Release a stamp -> replenishment brings back to target."""
+        manager = StampPoolManager(state_file=state_file)
+
+        # Add stamps up to target
+        manager.add_stamp_to_pool("stamp_a", 17, 1000000, 604800)
+        manager.add_stamp_to_pool("stamp_b", 17, 1000000, 604800)
+
+        # Release one
+        manager.release_stamp("stamp_a")
+        assert len(manager._pool) == 1
+
+        purchase_count = 0
+
+        async def mock_purchase(depth):
+            nonlocal purchase_count
+            purchase_count += 1
+            batch_id = f"replenished_{purchase_count}"
+            manager.add_stamp_to_pool(batch_id, depth, 1000000, 604800)
+            return batch_id
+
+        # Simulate check_and_replenish
+        bee_stamps = [
+            {"batchID": "stamp_b", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+        ]
+
+        with patch.object(manager, '_purchase_stamp', side_effect=mock_purchase):
+            with patch.object(manager, 'get_reserve_config', return_value={17: 2}):
+                with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+                    with patch.object(manager, '_update_stamp_ttls', new_callable=AsyncMock):
+                        with patch.object(manager, '_get_stamp_ttl', return_value=604800):
+                            with patch('app.services.stamp_pool.settings') as mock_settings:
+                                mock_settings.STAMP_POOL_ENABLED = True
+                                mock_settings.STAMP_POOL_MIN_TTL_HOURS = 24
+
+                                await manager.check_and_replenish()
+
+        assert purchase_count == 1
+        assert len(manager._pool) == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_respects_reserve_change(self, state_file):
+        """If reserve config changes (1 to 2), purchases the diff."""
+        # State has 1 stamp
+        with open(state_file, 'w') as f:
+            json.dump(["existing_1"], f)
+
+        bee_stamps = [
+            {"batchID": "existing_1", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+        ]
+
+        manager = StampPoolManager(state_file=state_file)
+        purchase_count = 0
+
+        async def mock_purchase(depth):
+            nonlocal purchase_count
+            purchase_count += 1
+            batch_id = f"new_{purchase_count}"
+            manager.add_stamp_to_pool(batch_id, depth, 1000000, 604800)
+            return batch_id
+
+        # Config now wants 2 stamps at depth 17
+        with patch.object(manager, '_purchase_stamp', side_effect=mock_purchase):
+            with patch.object(manager, 'get_reserve_config', return_value={17: 2}):
+                with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+                    with patch.object(manager, '_update_stamp_ttls', new_callable=AsyncMock):
+                        with patch.object(manager, '_get_stamp_ttl', return_value=604800):
+                            with patch('app.services.stamp_pool.settings') as mock_settings:
+                                mock_settings.STAMP_POOL_ENABLED = True
+                                mock_settings.STAMP_POOL_MIN_TTL_HOURS = 24
+
+                                await manager.check_and_replenish()
+
+        assert purchase_count == 1  # Only purchased the diff
+        assert len(manager._pool) == 2
+
+    @pytest.mark.asyncio
+    async def test_pool_does_not_shrink_below_target(self, state_file):
+        """If reserve lowered (2->1), doesn't remove stamps (natural attrition)."""
+        with open(state_file, 'w') as f:
+            json.dump(["stamp_1", "stamp_2"], f)
+
+        bee_stamps = [
+            {"batchID": "stamp_1", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+            {"batchID": "stamp_2", "depth": 17, "local": True, "usable": True, "batchTTL": 604800, "amount": "1000000", "label": ""},
+        ]
+
+        manager = StampPoolManager(state_file=state_file)
+        purchase_count = 0
+
+        async def mock_purchase(depth):
+            nonlocal purchase_count
+            purchase_count += 1
+            return f"new_{purchase_count}"
+
+        # Config now wants only 1, but pool has 2
+        with patch.object(manager, '_purchase_stamp', side_effect=mock_purchase):
+            with patch.object(manager, 'get_reserve_config', return_value={17: 1}):
+                with patch('app.services.stamp_pool.swarm_api.get_all_stamps_processed', return_value=bee_stamps):
+                    with patch.object(manager, '_update_stamp_ttls', new_callable=AsyncMock):
+                        with patch.object(manager, '_get_stamp_ttl', return_value=604800):
+                            with patch('app.services.stamp_pool.settings') as mock_settings:
+                                mock_settings.STAMP_POOL_ENABLED = True
+                                mock_settings.STAMP_POOL_MIN_TTL_HOURS = 24
+
+                                await manager.check_and_replenish()
+
+        # Should not purchase anything AND should not remove stamps
+        assert purchase_count == 0
+        assert len(manager._pool) == 2  # Both stamps kept


### PR DESCRIPTION
## Summary

- Fix stamp pool importing all matching stamps from the Bee node on every sync (52+ imported when reserve configured for 1+1)
- Add persistent state file (`data/pool_state.json`) that tracks which batch IDs the pool owns
- On restart, only re-import stamps found in the state file; expired/missing stamps are cleaned
- First run with no state file starts empty and purchases up to the reserve target
- Docker volume mounts (`/opt/swarm_connect_data`) preserve state across container restarts

## Test plan

- [ ] 18 new tests pass covering state persistence, sync behavior, and resize behavior (51 total pool tests)
- [ ] Full test suite passes (725 tests)
- [ ] Verify Docker build succeeds: `docker compose build`
- [ ] Start with empty `data/` dir — pool should purchase fresh stamps, not import 52
- [ ] Check `/api/v1/pool/status` shows only reserve-count stamps
- [ ] Restart gateway — verify same stamps restored from state file

Closes #123