### PR TITLE
Improve free tier discoverability for integrators

### DIFF
--- a/app/api/endpoints/data.py
+++ b/app/api/endpoints/data.py
@@ -113,6 +113,13 @@ async def upload_data(
     """
     Upload data to the Swarm network via the configured Bee node.
 
+    **x402 Payment** (when gateway has x402 enabled):
+    This endpoint requires payment OR free tier access. Check `GET /health` for availability.
+    - **Free tier**: Add header `X-Payment-Mode: free` (rate limited)
+    - **Paid**: Include x402 payment header (higher rate limit)
+    - Without either header, returns **HTTP 402** with payment instructions and free tier info
+    - Downloads (`GET /api/v1/data/{reference}`) are always free — no headers needed
+
     **Requirements**:
     - Upload as **multipart/form-data** with a `file` field
     - Valid `stamp_id` query parameter required
@@ -163,6 +170,11 @@ async def upload_data(
 
     **Usage Examples**:
     ```bash
+    # Upload with free tier (when x402 is enabled)
+    curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=ABC123" \\
+         -H "X-Payment-Mode: free" \\
+         -F "file=@data.json"
+
     # Upload JSON file (direct mode, default)
     curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=ABC123&content_type=application/json" \\
          -F "file=@data.json"
@@ -408,6 +420,8 @@ async def download_data(
     """
     Download data from the Swarm network as a file (triggers browser download).
 
+    **Always free** — no payment or headers required, even when x402 is enabled.
+
     **Use case**: End users downloading files, browser integration
 
     **Features**:
@@ -452,6 +466,8 @@ async def download_data_json(
 ):
     """
     Download data from the Swarm network as JSON with metadata (for API clients).
+
+    **Always free** — no payment or headers required, even when x402 is enabled.
 
     **Use case**: Web apps, mobile apps, API integrations needing metadata
 
@@ -514,6 +530,12 @@ async def upload_manifest(
     This endpoint bundles multiple files in a single upload for improved performance.
     The TAR archive is uploaded with the `Swarm-Collection: true` header, creating
     a manifest that maps file paths to their individual Swarm references.
+
+    **x402 Payment** (when gateway has x402 enabled):
+    This endpoint requires payment OR free tier access. Check `GET /health` for availability.
+    - **Free tier**: Add header `X-Payment-Mode: free` (rate limited)
+    - **Paid**: Include x402 payment header (higher rate limit)
+    - Without either header, returns **HTTP 402** with payment instructions and free tier info
 
     **Performance benefit**: Uploading 50 files as a TAR manifest takes ~500ms vs
     ~14 seconds for sequential individual uploads (15x improvement).

--- a/app/api/endpoints/pool.py
+++ b/app/api/endpoints/pool.py
@@ -160,7 +160,26 @@ async def acquire_stamp(
     request: AcquireStampRequest,
     http_request: Request
 ):
-    """Acquire a stamp from the pool."""
+    """
+    Acquire a stamp from the pool for immediate use (~5 seconds vs >1 minute).
+
+    **x402 Payment** (when gateway has x402 enabled):
+    This endpoint requires payment OR free tier access. Check `GET /health` for availability.
+    - **Free tier**: Add header `X-Payment-Mode: free` (rate limited)
+    - **Paid**: Include x402 payment header (higher rate limit)
+    - Without either header, returns **HTTP 402** with payment instructions and free tier info
+
+    **Quick start** (free tier):
+    ```bash
+    curl -X POST http://gateway/api/v1/pool/acquire \\
+         -H "Content-Type: application/json" \\
+         -H "X-Payment-Mode: free" \\
+         -d '{"size": "small"}'
+    ```
+
+    The stamp is released from the pool and becomes the caller's responsibility.
+    Use the returned `batch_id` as the `stamp_id` parameter for data uploads.
+    """
     if not settings.STAMP_POOL_ENABLED:
         raise HTTPException(
             status_code=404,

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -266,6 +266,15 @@ async def purchase_stamp(
     """
     Purchases a new postage stamp from the Swarm network.
 
+    **x402 Payment** (when gateway has x402 enabled):
+    This endpoint requires payment OR free tier access. Check `GET /health` for availability.
+    - **Free tier**: Add header `X-Payment-Mode: free` (rate limited)
+    - **Paid**: Include x402 payment header (higher rate limit)
+    - Without either header, returns **HTTP 402** with payment instructions and free tier info
+
+    **Tip**: For faster stamp acquisition, use `POST /api/v1/pool/acquire` instead (instant
+    from pre-purchased pool vs ~1 minute for on-chain purchase).
+
     Creates a new postage stamp batch with the specified duration or amount and depth.
     If duration_hours is provided, amount is calculated based on current network price.
     If neither is provided, defaults to 25 hours duration.
@@ -280,7 +289,7 @@ async def purchase_stamp(
         StampPurchaseResponse: Contains the new batch ID and success message
 
     Raises:
-        HTTPException: 400 if insufficient funds, 502 if Swarm API is unreachable
+        HTTPException: 400 if insufficient funds, 402 if payment required, 502 if Swarm API is unreachable
     """
     try:
         # Get effective depth from size preset or explicit depth

--- a/app/main.py
+++ b/app/main.py
@@ -85,13 +85,27 @@ app.include_router(notary.router, prefix=f"{settings.API_V1_STR}/notary", tags=[
 @app.get("/health", summary="Health Check", tags=["default"], include_in_schema=False)
 def read_root():
     """
-    Health check endpoint.
+    Health check endpoint. Use this to discover gateway capabilities before making requests.
 
-    When X402_ENABLED=true, includes x402 wallet status:
-    - status: "ok" | "degraded" | "critical"
-    - x402: detailed wallet balances and warnings
+    **Response fields**:
+    - `status`: "ok" | "degraded" | "critical"
+    - `message`: Gateway name
+    - `x402` (when payments enabled): wallet status, free tier availability, and warnings
 
-    Returns 503 when x402 is enabled and gateway wallet is critically low on ETH.
+    **When x402 payments are enabled**, the response includes:
+    - `x402.enabled`: true
+    - `x402.free_tier.enabled`: whether free tier access is available
+    - `x402.free_tier.rate_limit_per_minute`: requests allowed per minute on free tier
+    - `x402.free_tier.header`: the exact header to add for free tier access
+    - `x402.base_wallet`: USDC receiving wallet status
+    - `x402.bee_gnosis_wallet`: Bee node wallet balances
+
+    **Integrator quick start** (when x402 is enabled and free tier is available):
+    1. Call `GET /health` — check `x402.free_tier.enabled` is `true`
+    2. Add header `X-Payment-Mode: free` to all POST requests
+    3. Acquire a stamp: `POST /api/v1/pool/acquire`
+    4. Upload data: `POST /api/v1/data/?stamp_id=...`
+    5. Download data: `GET /api/v1/data/{reference}` (always free, no headers needed)
     """
     logger.info("Health check endpoint accessed.")
 
@@ -134,6 +148,11 @@ def read_root():
         # Add x402 details
         response_data["x402"] = {
             "enabled": True,
+            "free_tier": {
+                "enabled": settings.X402_FREE_TIER_ENABLED,
+                "rate_limit_per_minute": settings.X402_FREE_TIER_RATE_LIMIT,
+                "header": "X-Payment-Mode: free",
+            },
             "base_wallet": {
                 "address": base_eth.get("address"),
                 "balance_eth": base_eth.get("balance_eth"),

--- a/tests/test_integration_gateway.py
+++ b/tests/test_integration_gateway.py
@@ -191,10 +191,11 @@ class TestManifestUploadIntegration:
         }
         tar_data = create_test_tar(test_files)
 
-        # Upload via manifest endpoint
+        # Upload via manifest endpoint (use free tier header for x402-enabled gateways)
         response = requests.post(
             f"{GATEWAY_URL}/api/v1/data/manifest",
             params={"stamp_id": usable_stamp},
+            headers={"X-Payment-Mode": "free"},
             files={"file": ("test.tar", tar_data, "application/x-tar")},
             timeout=120
         )


### PR DESCRIPTION
## Summary
- Health endpoint (`GET /`) now includes `x402.free_tier` section showing availability, rate limit, and exact header to use
- All protected endpoint docstrings (upload, manifest, stamps purchase, pool acquire) now document x402 payment / free tier requirements
- Download endpoints explicitly state they are always free
- Pool acquire includes a quick start curl example for free tier
- Fix integration test that broke when x402 was enabled on production

## Problem
Integrators couldn't discover how to use free tier from the API itself — the info was only in separate guide docs, not in the health endpoint or OpenAPI specs.

## Changes
- `app/main.py` — health endpoint docstring + `free_tier` in x402 response
- `app/api/endpoints/data.py` — upload + manifest + download docstrings
- `app/api/endpoints/stamps.py` — purchase docstring
- `app/api/endpoints/pool.py` — acquire docstring with example
- `tests/test_integration_gateway.py` — add free tier header to manifest test