### PR TITLE
Release: stamp propagation timing signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,11 @@ SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
 # SSL_KEYFILE=./localhost+2-key.pem           # Path to SSL key file (for HTTPS dev)
 # SSL_CERTFILE=./localhost+2.pem              # Path to SSL certificate file (for HTTPS dev)
 
+# === Stamp Propagation Timing ===
+# Expected propagation delay (in seconds) after purchasing a new stamp.
+# Used to calculate propagation timing signals (propagationStatus, estimatedReadyAt).
+# STAMP_PROPAGATION_SECONDS=120
+
 # === Upload Limits ===
 # Maximum file upload size in megabytes (default: 10)
 # MAX_UPLOAD_SIZE_MB=10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,11 +65,19 @@ python -m pytest tests/test_manifest_upload.py -v
 - Handles HTTP requests to Swarm Bee API (`/batches` endpoint)
 - Includes error handling for network issues and malformed responses
 - Supports both direct list responses and `{"batches": [...]}` wrapper formats
+- `calculate_propagation_signals()`: Computes propagation timing for stamps purchased through this gateway
+
+**Stamp Purchase Tracker (`app/services/stamp_tracker.py`)**:
+- In-memory tracker for stamps purchased through this gateway
+- Records purchase timestamps to calculate propagation timing signals
+- Auto-prunes entries older than 10 minutes to prevent unbounded growth
+- Functions: `record_purchase()`, `get_purchase_time()`, `clear_tracker()`
 
 **Stamps API (`app/api/endpoints/stamps.py`)**:
 - Provides `/api/v1/stamps/{stamp_id}` endpoint
 - Fetches all stamps from Swarm and filters by ID
 - Calculates expiration time: `current_time + batchTTL`
+- Records purchase timestamps for propagation tracking on `POST /stamps/`
 - Comprehensive error handling with appropriate HTTP status codes
 
 **Data Models (`app/api/models/stamp.py`)**:
@@ -77,6 +85,7 @@ python -m pytest tests/test_manifest_upload.py -v
 - Field aliases for API compatibility (`amount` aliased as `value`, etc.)
 - Calculated `expectedExpiration` field in `YYYY-MM-DD-HH-MM` UTC format
 - Calculated `utilizationPercent` field showing stamp usage as percentage (0-100%)
+- Propagation timing fields: `secondsSincePurchase`, `estimatedReadyAt`, `propagationStatus`
 
 ### Environment Configuration
 
@@ -88,6 +97,9 @@ Optional environment variables:
 - `PORT`: Server port (default: `8000`)
 - `RELOAD`: Enable auto-reload (default: `true`)
 - `SSL_KEYFILE`/`SSL_CERTFILE`: For HTTPS development
+
+Stamp propagation:
+- `STAMP_PROPAGATION_SECONDS`: Expected propagation delay after purchase in seconds (default: `120`)
 
 Security settings:
 - `MAX_UPLOAD_SIZE_MB`: Maximum file upload size in megabytes (default: `10`)
@@ -109,11 +121,16 @@ CORS (browser access):
 - `GET /`: Health check endpoint
 
 #### Stamp Management
-- `POST /api/v1/stamps/`: Purchase new postage stamps
-- `GET /api/v1/stamps/`: List all available stamps with expiration calculations
-- `GET /api/v1/stamps/{stamp_id}`: Retrieve specific stamp batch details
-- `GET /api/v1/stamps/{stamp_id}/check`: Check stamp health for uploads (errors, warnings, can_upload status)
+- `POST /api/v1/stamps/`: Purchase new postage stamps (records purchase time for propagation tracking)
+- `GET /api/v1/stamps/`: List all available stamps with expiration calculations and propagation status
+- `GET /api/v1/stamps/{stamp_id}`: Retrieve specific stamp batch details including propagation timing
+- `GET /api/v1/stamps/{stamp_id}/check`: Check stamp health for uploads (errors, warnings, can_upload status, propagation status)
 - `PATCH /api/v1/stamps/{stamp_id}/extend`: Extend existing stamps with additional funds
+
+**Propagation timing fields** (included in all stamp responses):
+- `secondsSincePurchase`: Seconds elapsed since purchase through this gateway (null for external stamps)
+- `estimatedReadyAt`: ISO 8601 timestamp when stamp should be usable (null for external stamps)
+- `propagationStatus`: `"ready"` / `"propagating"` / `"unknown"` (null if undetermined)
 
 #### Data Operations
 - `POST /api/v1/data/?stamp_id={id}&content_type={type}&redundancy={level}`: Upload raw data to Swarm (redundancy 0-4, default 2)

--- a/README.md
+++ b/README.md
@@ -696,7 +696,10 @@ Perform a comprehensive health check on a stamp to determine if it can be used f
     "utilizationPercent": 82.5,
     "utilizationStatus": "warning",
     "batchTTL": 86400,
-    "expectedExpiration": "2026-01-12-17-30"
+    "expectedExpiration": "2026-01-12-17-30",
+    "secondsSincePurchase": null,
+    "estimatedReadyAt": null,
+    "propagationStatus": "ready"
   }
 }
 ```
@@ -803,12 +806,18 @@ The `Server` header is suppressed in all responses to prevent version fingerprin
 3. Purchase a new stamp through this node
 
 #### "Stamp is not yet usable" (NOT_USABLE)
-**Cause:** After purchasing a stamp, there's a 30-90 second propagation delay before it can be used.
+**Cause:** After purchasing a stamp, there's a ~2 minute propagation delay before it can be used.
 
 **Solutions:**
-1. Wait 30-90 seconds after purchase
-2. Check stamp status with `GET /api/v1/stamps/{stamp_id}/check`
-3. The `usable` field will change from `false` to `true` when ready
+1. Wait for the stamp to propagate (~2 minutes after purchase)
+2. Check stamp status with `GET /api/v1/stamps/{stamp_id}/check` — use the `propagationStatus` field
+3. The `propagationStatus` field transitions: `"propagating"` → `"ready"` when the stamp becomes usable
+4. Use `estimatedReadyAt` (ISO 8601) to know when to retry
+
+**Propagation timing fields** (available on all stamp responses):
+- `secondsSincePurchase`: How long since purchase through this gateway (null for external stamps)
+- `estimatedReadyAt`: ISO 8601 timestamp when stamp should be ready
+- `propagationStatus`: `"propagating"` (waiting), `"ready"` (usable), `"unknown"` (not tracked by this gateway)
 
 **Example workflow after purchase:**
 ```bash
@@ -818,11 +827,11 @@ curl -X POST "http://localhost:8000/api/v1/stamps/" \
      -d '{"duration_hours": 25, "size": "small"}'
 # Response: {"batchID": "abc123...", "message": "..."}
 
-# Check if ready (repeat until can_upload=true)
+# Check propagation status (repeat until propagationStatus="ready")
 curl "http://localhost:8000/api/v1/stamps/abc123.../check"
-# Wait for: {"can_upload": true, ...}
+# Response includes: "propagationStatus": "propagating", "estimatedReadyAt": "2026-03-16T12:02:00+00:00"
 
-# Now upload
+# Now upload (once propagationStatus="ready")
 curl -X POST "http://localhost:8000/api/v1/data/?stamp_id=abc123..." \
      -F "file=@data.json"
 ```

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -7,6 +7,7 @@ import logging
 
 from app.services import swarm_api
 from app.services.stamp_ownership import stamp_ownership_manager
+from app.services.stamp_tracker import record_purchase
 from app.api.models.stamp import (
     StampDetails,
     StampPurchaseRequest,
@@ -149,7 +150,10 @@ async def check_stamp_health(
                 utilizationPercent=status_data.get("utilizationPercent"),
                 utilizationStatus=status_data.get("utilizationStatus"),
                 batchTTL=status_data.get("batchTTL"),
-                expectedExpiration=status_data.get("expectedExpiration")
+                expectedExpiration=status_data.get("expectedExpiration"),
+                secondsSincePurchase=status_data.get("secondsSincePurchase"),
+                estimatedReadyAt=status_data.get("estimatedReadyAt"),
+                propagationStatus=status_data.get("propagationStatus")
             )
         )
 
@@ -228,6 +232,9 @@ async def get_stamp_details(
             utilizationWarning=found_stamp.get("utilizationWarning"),
             usable=found_stamp.get("usable"),
             label=found_stamp.get("label"),
+            secondsSincePurchase=found_stamp.get("secondsSincePurchase"),
+            estimatedReadyAt=found_stamp.get("estimatedReadyAt"),
+            propagationStatus=found_stamp.get("propagationStatus"),
             expectedExpiration=found_stamp.get("expectedExpiration"),
             local=found_stamp.get("local")
         )
@@ -327,6 +334,9 @@ async def purchase_stamp(
             depth=effective_depth,
             label=stamp_request.label
         )
+
+        # Record purchase time for propagation tracking
+        record_purchase(batch_id)
 
         # Register stamp ownership
         x402_mode = getattr(request.state, 'x402_mode', None)

--- a/app/api/models/stamp.py
+++ b/app/api/models/stamp.py
@@ -42,6 +42,14 @@ class StampDetails(BaseModel):
     usable: Optional[bool] = Field(None, description="Stamp usability status. False when stamp is expired, invalid, or at 100% utilization.")
     label: Optional[str] = Field(None, description="User-defined label (from local /stamps endpoint when available).")
 
+    # --- Propagation Timing Fields ---
+    secondsSincePurchase: Optional[int] = Field(None, description="Seconds elapsed since purchase through this gateway. Null for stamps not purchased through this gateway.")
+    estimatedReadyAt: Optional[str] = Field(None, description="ISO 8601 timestamp when stamp should be usable after propagation. Null for stamps not purchased through this gateway.")
+    propagationStatus: Optional[Literal["ready", "propagating", "unknown"]] = Field(
+        None,
+        description="Propagation status: 'ready' (usable), 'propagating' (waiting for network), 'unknown' (not tracked by this gateway). Null if status cannot be determined."
+    )
+
     # --- Calculated Fields ---
     expectedExpiration: str = Field(..., description="Calculated expiration timestamp (YYYY-MM-DD-HH-MM UTC).")
     local: bool = Field(..., description="Indicates if this stamp is owned/managed by the local node.")
@@ -65,6 +73,9 @@ class StampDetails(BaseModel):
                 "utilizationWarning": None,
                 "usable": True,
                 "label": None,
+                "secondsSincePurchase": 45,
+                "estimatedReadyAt": "2024-08-15T08:32:00+00:00",
+                "propagationStatus": "propagating",
                 "expectedExpiration": "2024-08-15-10-30",
                 "local": True
             }
@@ -238,6 +249,9 @@ class StampHealthStatus(BaseModel):
     utilizationStatus: Optional[Literal["ok", "warning", "critical", "full"]] = Field(None, description="Utilization status category")
     batchTTL: Optional[int] = Field(None, description="Time-to-live in seconds")
     expectedExpiration: Optional[str] = Field(None, description="Expected expiration timestamp (YYYY-MM-DD-HH-MM UTC)")
+    secondsSincePurchase: Optional[int] = Field(None, description="Seconds elapsed since purchase through this gateway")
+    estimatedReadyAt: Optional[str] = Field(None, description="ISO 8601 timestamp when stamp should be usable")
+    propagationStatus: Optional[Literal["ready", "propagating", "unknown"]] = Field(None, description="Propagation status: 'ready', 'propagating', or 'unknown'")
 
 
 class StampHealthCheckResponse(BaseModel):
@@ -268,7 +282,10 @@ class StampHealthCheckResponse(BaseModel):
                     "utilizationPercent": 82.5,
                     "utilizationStatus": "warning",
                     "batchTTL": 86400,
-                    "expectedExpiration": "2026-01-12-17-30"
+                    "expectedExpiration": "2026-01-12-17-30",
+                    "secondsSincePurchase": None,
+                    "estimatedReadyAt": None,
+                    "propagationStatus": "ready"
                 }
             }
         }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -92,6 +92,9 @@ class Settings(BaseSettings):
     NOTARY_ENABLED: bool = False  # Master switch for notary signing feature
     NOTARY_PRIVATE_KEY: Optional[str] = None  # Hex-encoded private key for signing (without 0x prefix)
 
+    # === Stamp Propagation Timing ===
+    STAMP_PROPAGATION_SECONDS: int = 120  # Expected propagation delay after purchase (~2 minutes)
+
     # === Upload Limits ===
     MAX_UPLOAD_SIZE_MB: int = 10  # Maximum file upload size in megabytes
 

--- a/app/services/stamp_tracker.py
+++ b/app/services/stamp_tracker.py
@@ -1,0 +1,50 @@
+# app/services/stamp_tracker.py
+"""
+In-memory tracker for stamps purchased through this gateway.
+
+Records purchase timestamps so we can calculate propagation timing signals
+(secondsSincePurchase, estimatedReadyAt, propagationStatus) for consumers
+polling stamp status after purchase.
+
+Only tracks stamps bought via our gateway — external stamps show "unknown"
+propagation status, which is correct since we don't know when they were purchased.
+"""
+import datetime
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Maximum age before entries are pruned (10 minutes)
+_MAX_TRACKER_AGE_SECONDS = 600
+
+# In-memory store: batchID -> purchase timestamp (UTC)
+_purchase_times: Dict[str, datetime.datetime] = {}
+
+
+def record_purchase(batch_id: str) -> None:
+    """Record the purchase timestamp for a stamp bought through this gateway."""
+    _prune_old_entries()
+    _purchase_times[batch_id] = datetime.datetime.now(datetime.timezone.utc)
+    logger.info(f"Recorded purchase time for stamp {batch_id[:16]}...")
+
+
+def get_purchase_time(batch_id: str) -> Optional[datetime.datetime]:
+    """Get the purchase timestamp for a gateway-purchased stamp, or None if unknown."""
+    return _purchase_times.get(batch_id)
+
+
+def clear_tracker() -> None:
+    """Clear all tracked purchases. Used for testing."""
+    _purchase_times.clear()
+
+
+def _prune_old_entries() -> None:
+    """Remove entries older than _MAX_TRACKER_AGE_SECONDS to prevent unbounded growth."""
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cutoff = now - datetime.timedelta(seconds=_MAX_TRACKER_AGE_SECONDS)
+    stale_ids = [bid for bid, ts in _purchase_times.items() if ts < cutoff]
+    for bid in stale_ids:
+        del _purchase_times[bid]
+    if stale_ids:
+        logger.debug(f"Pruned {len(stale_ids)} old stamp tracker entries")

--- a/app/services/swarm_api.py
+++ b/app/services/swarm_api.py
@@ -1,4 +1,5 @@
 # app/services/swarm_api.py
+import datetime
 import requests
 from requests.exceptions import RequestException
 import logging
@@ -375,6 +376,61 @@ def calculate_utilization_status(
         return ("ok", None)
 
 
+def calculate_propagation_signals(batch_id: str, usable: Optional[bool]) -> Dict[str, Any]:
+    """
+    Calculates propagation timing signals for a stamp.
+
+    Logic:
+    - If usable is True → "ready" (regardless of tracker state)
+    - If tracked and within propagation window → "propagating" with timing fields
+    - If tracked and past window → "ready"
+    - If not tracked and usable is False → "unknown" (external stamp)
+    - If not tracked and usable is None → "unknown"
+
+    Returns:
+        Dict with keys: secondsSincePurchase, estimatedReadyAt, propagationStatus
+        (all may be None)
+    """
+    from app.services.stamp_tracker import get_purchase_time
+
+    result = {
+        "secondsSincePurchase": None,
+        "estimatedReadyAt": None,
+        "propagationStatus": None,
+    }
+
+    purchase_time = get_purchase_time(batch_id)
+    propagation_seconds = settings.STAMP_PROPAGATION_SECONDS
+
+    if usable is True:
+        # Stamp is usable — always "ready"
+        result["propagationStatus"] = "ready"
+        if purchase_time:
+            now = datetime.datetime.now(datetime.timezone.utc)
+            result["secondsSincePurchase"] = int((now - purchase_time).total_seconds())
+            estimated_ready = purchase_time + datetime.timedelta(seconds=propagation_seconds)
+            result["estimatedReadyAt"] = estimated_ready.isoformat()
+        return result
+
+    if purchase_time:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        elapsed = int((now - purchase_time).total_seconds())
+        estimated_ready = purchase_time + datetime.timedelta(seconds=propagation_seconds)
+
+        result["secondsSincePurchase"] = elapsed
+        result["estimatedReadyAt"] = estimated_ready.isoformat()
+
+        if elapsed >= propagation_seconds:
+            result["propagationStatus"] = "ready"
+        else:
+            result["propagationStatus"] = "propagating"
+        return result
+
+    # Not tracked by this gateway
+    result["propagationStatus"] = "unknown"
+    return result
+
+
 def get_all_stamps_processed() -> List[Dict[str, Any]]:
     """
     Fetches all postage stamp batches and processes them with expiration calculations.
@@ -387,8 +443,6 @@ def get_all_stamps_processed() -> List[Dict[str, Any]]:
     Raises:
         RequestException: If the HTTP request to the Swarm API fails.
     """
-    import datetime
-
     # Get stamps data from both endpoints
     global_stamps = get_all_stamps()  # /batches endpoint
     local_stamps = get_local_stamps()  # /stamps endpoint
@@ -438,6 +492,9 @@ def get_all_stamps_processed() -> List[Dict[str, Any]]:
             if usable is None or (utilization_percent is not None and utilization_percent >= UTILIZATION_THRESHOLD_FULL):
                 usable = calculate_usable_status(merged_stamp, utilization_percent)
 
+            # Calculate propagation signals
+            propagation = calculate_propagation_signals(batch_id, usable)
+
             # Create processed stamp data
             processed_stamp = {
                 "batchID": batch_id,
@@ -447,6 +504,9 @@ def get_all_stamps_processed() -> List[Dict[str, Any]]:
                 "utilizationWarning": utilization_warning,
                 "usable": usable,
                 "label": merged_stamp.get("label"),
+                "secondsSincePurchase": propagation["secondsSincePurchase"],
+                "estimatedReadyAt": propagation["estimatedReadyAt"],
+                "propagationStatus": propagation["propagationStatus"],
                 "depth": merged_stamp.get("depth"),
                 "amount": str(merged_stamp.get("amount", "")),  # Ensure amount is string
                 "bucketDepth": merged_stamp.get("bucketDepth"),
@@ -1290,7 +1350,10 @@ def get_stamp_health_check(stamp_id: str) -> Dict[str, Any]:
                 "utilizationPercent": None,
                 "utilizationStatus": None,
                 "batchTTL": None,
-                "expectedExpiration": None
+                "expectedExpiration": None,
+                "secondsSincePurchase": None,
+                "estimatedReadyAt": None,
+                "propagationStatus": None
             }
         }
 
@@ -1319,7 +1382,10 @@ def get_stamp_health_check(stamp_id: str) -> Dict[str, Any]:
                 "utilizationPercent": None,
                 "utilizationStatus": None,
                 "batchTTL": None,
-                "expectedExpiration": None
+                "expectedExpiration": None,
+                "secondsSincePurchase": None,
+                "estimatedReadyAt": None,
+                "propagationStatus": None
             }
         }
 
@@ -1338,7 +1404,10 @@ def get_stamp_health_check(stamp_id: str) -> Dict[str, Any]:
         "utilizationPercent": utilization_percent,
         "utilizationStatus": utilization_status,
         "batchTTL": batch_ttl,
-        "expectedExpiration": expected_expiration
+        "expectedExpiration": expected_expiration,
+        "secondsSincePurchase": found_stamp.get("secondsSincePurchase"),
+        "estimatedReadyAt": found_stamp.get("estimatedReadyAt"),
+        "propagationStatus": found_stamp.get("propagationStatus")
     }
 
     # Check for errors (blocking issues)

--- a/tests/test_stamp_propagation.py
+++ b/tests/test_stamp_propagation.py
@@ -1,0 +1,334 @@
+# tests/test_stamp_propagation.py
+"""Tests for stamp propagation timing signals."""
+import datetime
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import stamp_tracker
+from app.services.swarm_api import calculate_propagation_signals
+
+client = TestClient(app)
+
+VALID_STAMP_ID = "a" * 64
+VALID_STAMP_ID_B = "b" * 64
+
+
+class TestStampTracker:
+    """Unit tests for the in-memory stamp purchase tracker."""
+
+    def setup_method(self):
+        stamp_tracker.clear_tracker()
+
+    def test_record_and_retrieve(self):
+        """Record a purchase and retrieve its timestamp."""
+        stamp_tracker.record_purchase("batch123")
+        result = stamp_tracker.get_purchase_time("batch123")
+        assert result is not None
+        assert isinstance(result, datetime.datetime)
+        assert result.tzinfo == datetime.timezone.utc
+
+    def test_unknown_stamp_returns_none(self):
+        """Unknown stamp returns None."""
+        result = stamp_tracker.get_purchase_time("nonexistent")
+        assert result is None
+
+    def test_clear_tracker(self):
+        """clear_tracker removes all entries."""
+        stamp_tracker.record_purchase("batch1")
+        stamp_tracker.record_purchase("batch2")
+        stamp_tracker.clear_tracker()
+        assert stamp_tracker.get_purchase_time("batch1") is None
+        assert stamp_tracker.get_purchase_time("batch2") is None
+
+    def test_auto_cleanup_old_entries(self):
+        """Entries older than 10 minutes are pruned on next record_purchase."""
+        # Insert an old entry directly
+        old_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(minutes=15)
+        stamp_tracker._purchase_times["old_batch"] = old_time
+
+        # Insert a fresh entry — should trigger pruning
+        stamp_tracker.record_purchase("new_batch")
+
+        assert stamp_tracker.get_purchase_time("old_batch") is None
+        assert stamp_tracker.get_purchase_time("new_batch") is not None
+
+    def test_recent_entries_not_pruned(self):
+        """Entries within the 10-minute window survive pruning."""
+        stamp_tracker.record_purchase("recent_batch")
+        # Trigger pruning by recording another
+        stamp_tracker.record_purchase("another_batch")
+        assert stamp_tracker.get_purchase_time("recent_batch") is not None
+
+
+class TestCalculatePropagationSignals:
+    """Unit tests for calculate_propagation_signals logic."""
+
+    def setup_method(self):
+        stamp_tracker.clear_tracker()
+
+    @patch("app.services.swarm_api.settings")
+    def test_tracked_within_window_propagating(self, mock_settings):
+        """Tracked stamp within propagation window → 'propagating'."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+        stamp_tracker.record_purchase("batch_new")
+
+        result = calculate_propagation_signals("batch_new", usable=False)
+
+        assert result["propagationStatus"] == "propagating"
+        assert result["secondsSincePurchase"] is not None
+        assert result["secondsSincePurchase"] >= 0
+        assert result["estimatedReadyAt"] is not None
+
+    @patch("app.services.swarm_api.settings")
+    def test_tracked_past_window_ready(self, mock_settings):
+        """Tracked stamp past propagation window → 'ready'."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+        # Insert entry from 3 minutes ago
+        old_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(seconds=180)
+        stamp_tracker._purchase_times["batch_old"] = old_time
+
+        result = calculate_propagation_signals("batch_old", usable=False)
+
+        assert result["propagationStatus"] == "ready"
+        assert result["secondsSincePurchase"] >= 180
+        assert result["estimatedReadyAt"] is not None
+
+    @patch("app.services.swarm_api.settings")
+    def test_untracked_usable_true_ready(self, mock_settings):
+        """Untracked stamp with usable=True → 'ready' (covers pool stamps)."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+
+        result = calculate_propagation_signals("unknown_batch", usable=True)
+
+        assert result["propagationStatus"] == "ready"
+        assert result["secondsSincePurchase"] is None
+        assert result["estimatedReadyAt"] is None
+
+    @patch("app.services.swarm_api.settings")
+    def test_untracked_usable_false_unknown(self, mock_settings):
+        """Untracked stamp with usable=False → 'unknown'."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+
+        result = calculate_propagation_signals("external_batch", usable=False)
+
+        assert result["propagationStatus"] == "unknown"
+        assert result["secondsSincePurchase"] is None
+        assert result["estimatedReadyAt"] is None
+
+    @patch("app.services.swarm_api.settings")
+    def test_untracked_usable_none_unknown(self, mock_settings):
+        """Untracked stamp with usable=None → 'unknown'."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+
+        result = calculate_propagation_signals("no_info_batch", usable=None)
+
+        assert result["propagationStatus"] == "unknown"
+
+    @patch("app.services.swarm_api.settings")
+    def test_usable_true_always_ready_even_if_tracked(self, mock_settings):
+        """usable=True always → 'ready' even if tracker says recently purchased."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+        stamp_tracker.record_purchase("batch_just_bought")
+
+        result = calculate_propagation_signals("batch_just_bought", usable=True)
+
+        assert result["propagationStatus"] == "ready"
+        # Timing fields still populated for tracked stamps
+        assert result["secondsSincePurchase"] is not None
+        assert result["estimatedReadyAt"] is not None
+
+    @patch("app.services.swarm_api.settings")
+    def test_estimated_ready_at_is_iso_format(self, mock_settings):
+        """estimatedReadyAt should be a valid ISO 8601 string."""
+        mock_settings.STAMP_PROPAGATION_SECONDS = 120
+        stamp_tracker.record_purchase("batch_iso")
+
+        result = calculate_propagation_signals("batch_iso", usable=False)
+
+        # Should parse as ISO 8601
+        parsed = datetime.datetime.fromisoformat(result["estimatedReadyAt"])
+        assert parsed.tzinfo is not None
+
+
+class TestPropagationIntegration:
+    """Integration tests for propagation fields in API responses."""
+
+    def setup_method(self):
+        stamp_tracker.clear_tracker()
+
+    def _make_stamp_data(self, batch_id, usable=True, **overrides):
+        """Helper to create complete stamp data dict."""
+        data = {
+            "batchID": batch_id,
+            "amount": "1000000000",
+            "blockNumber": 12345,
+            "owner": "0xabcdef",
+            "immutableFlag": False,
+            "depth": 20,
+            "bucketDepth": 16,
+            "batchTTL": 86400,
+            "utilization": 5,
+            "utilizationPercent": 31.25,
+            "utilizationStatus": "ok",
+            "utilizationWarning": None,
+            "usable": usable,
+            "label": None,
+            "secondsSincePurchase": None,
+            "estimatedReadyAt": None,
+            "propagationStatus": "ready" if usable else "unknown",
+            "expectedExpiration": "2026-03-17-12-00",
+            "local": True,
+        }
+        data.update(overrides)
+        return data
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_get_stamp_includes_propagation_fields(self, mock_get_stamps):
+        """GET /stamps/{id} includes propagation fields."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(VALID_STAMP_ID, propagationStatus="ready")
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert "secondsSincePurchase" in data
+        assert "estimatedReadyAt" in data
+        assert "propagationStatus" in data
+        assert data["propagationStatus"] == "ready"
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_list_stamps_includes_propagation_fields(self, mock_get_stamps):
+        """GET /stamps/ list includes propagation fields on each stamp."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(VALID_STAMP_ID),
+            self._make_stamp_data(VALID_STAMP_ID_B, usable=False, propagationStatus="unknown"),
+        ]
+
+        response = client.get("/api/v1/stamps/")
+
+        assert response.status_code == 200
+        stamps = response.json()["stamps"]
+        assert len(stamps) == 2
+
+        for stamp in stamps:
+            assert "propagationStatus" in stamp
+            assert "secondsSincePurchase" in stamp
+            assert "estimatedReadyAt" in stamp
+
+        assert stamps[0]["propagationStatus"] == "ready"
+        assert stamps[1]["propagationStatus"] == "unknown"
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_propagation_fields_null_for_untracked(self, mock_get_stamps):
+        """Propagation timing fields are null for untracked stamps."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(VALID_STAMP_ID, propagationStatus="unknown")
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["secondsSincePurchase"] is None
+        assert data["estimatedReadyAt"] is None
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_propagating_stamp_shows_timing(self, mock_get_stamps):
+        """A propagating stamp shows timing fields."""
+        now = datetime.datetime.now(datetime.timezone.utc)
+        estimated = (now + datetime.timedelta(seconds=80)).isoformat()
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(
+                VALID_STAMP_ID,
+                usable=False,
+                secondsSincePurchase=40,
+                estimatedReadyAt=estimated,
+                propagationStatus="propagating",
+            )
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["propagationStatus"] == "propagating"
+        assert data["secondsSincePurchase"] == 40
+        assert data["estimatedReadyAt"] is not None
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_health_check_includes_propagation(self, mock_get_stamps):
+        """GET /stamps/{id}/check includes propagation fields in status."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(
+                VALID_STAMP_ID,
+                usable=False,
+                secondsSincePurchase=30,
+                estimatedReadyAt="2026-03-16T12:02:00+00:00",
+                propagationStatus="propagating",
+            )
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}/check")
+
+        assert response.status_code == 200
+        status = response.json()["status"]
+        assert status["propagationStatus"] == "propagating"
+        assert status["secondsSincePurchase"] == 30
+        assert status["estimatedReadyAt"] == "2026-03-16T12:02:00+00:00"
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_health_check_ready_stamp(self, mock_get_stamps):
+        """Health check for a ready stamp shows propagationStatus='ready'."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(VALID_STAMP_ID, propagationStatus="ready")
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}/check")
+
+        assert response.status_code == 200
+        status = response.json()["status"]
+        assert status["propagationStatus"] == "ready"
+
+    @patch("app.services.swarm_api.check_sufficient_funds")
+    @patch("app.services.swarm_api.purchase_postage_stamp")
+    def test_purchase_records_in_tracker(self, mock_purchase, mock_funds):
+        """POST /stamps/ records the purchase in stamp_tracker."""
+        stamp_tracker.clear_tracker()
+        mock_purchase.return_value = "new_batch_abc123"
+        mock_funds.return_value = {
+            "sufficient": True,
+            "wallet_balance_bzz": 10.0,
+            "required_bzz": 0.1,
+            "shortfall_bzz": 0.0,
+        }
+
+        response = client.post(
+            "/api/v1/stamps/", json={"amount": 8000000000, "depth": 17}
+        )
+
+        assert response.status_code == 201
+        # Verify tracker recorded the purchase
+        purchase_time = stamp_tracker.get_purchase_time("new_batch_abc123")
+        assert purchase_time is not None
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_pool_stamps_show_ready(self, mock_get_stamps):
+        """Pool stamps (usable=True, not tracked) show propagationStatus='ready'."""
+        mock_get_stamps.return_value = [
+            self._make_stamp_data(
+                VALID_STAMP_ID,
+                usable=True,
+                propagationStatus="ready",
+            )
+        ]
+
+        response = client.get(f"/api/v1/stamps/{VALID_STAMP_ID}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["propagationStatus"] == "ready"
+        assert data["secondsSincePurchase"] is None


### PR DESCRIPTION
## Summary
- Merges dev into main, bringing stamp propagation timing signals (#137) to production
- All changes previously tested on staging at https://provenance-gateway.dev.datafund.io

## Key changes since last release
- Three new optional fields on all stamp responses: `secondsSincePurchase`, `estimatedReadyAt`, `propagationStatus`
- In-memory purchase tracker for gateway-bought stamps
- Configurable propagation window via `STAMP_PROPAGATION_SECONDS` (default 120s)
- Fully backward compatible — all new fields are Optional/null by default
- 20 new tests, 533 total passing