### PR TITLE
Add exclusive parameter to wallet stamp filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ CORS (browser access):
 **Stamp list query parameters**:
 - `global` (bool): If true, return all stamps including non-local (old behavior)
 - `wallet` (string): Filter to stamps accessible by this wallet address (requires x402 enabled)
+- `exclusive` (bool): When used with `wallet`, return only stamps purchased by this wallet (excludes shared/free and untracked)
 
 **Propagation timing fields** (included in all stamp responses):
 - `secondsSincePurchase`: Seconds elapsed since purchase through this gateway (null for external stamps)

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ List postage stamps. Default returns only local stamps (usable for uploads).
 |-----------|------|---------|-------------|
 | `global` | bool | `false` | If true, return all stamps including non-local |
 | `wallet` | string | - | Filter to stamps accessible by this wallet (requires x402 enabled) |
+| `exclusive` | bool | `false` | With `wallet`: only stamps purchased by this wallet (excludes shared/untracked) |
 
 - **Response**: `{"stamps": [...], "total_count": N}`
 - Each stamp includes `accessMode`: `"owned"` (exclusive), `"shared"` (free tier), or `null` (untracked)

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -47,6 +47,10 @@ async def list_stamps(
         alias="global",
         description="If true, return all stamps including non-local (old behavior)."
     ),
+    exclusive: Optional[bool] = Query(
+        default=None,
+        description="When used with wallet, return only stamps purchased by this wallet (excludes shared and untracked stamps)."
+    ),
 ) -> Any:
     """
     Retrieves a list of postage stamp batches from the Swarm network.
@@ -58,6 +62,7 @@ async def list_stamps(
     - `?global=true` — Return all stamps visible on the network (old behavior)
     - `?wallet=0xABC...` — Return stamps accessible by this wallet (owned + shared + untracked local).
       Only effective when x402 is enabled; ignored otherwise.
+    - `?wallet=0xABC...&exclusive=true` — Return only stamps purchased by this wallet (excludes shared/free and untracked stamps).
 
     Returns:
         StampListResponse: Contains list of filtered stamps and total count
@@ -83,13 +88,20 @@ async def list_stamps(
             # No filtering — return everything (old behavior)
             pass
         elif wallet and settings.X402_ENABLED:
-            # Show stamps accessible to this wallet
-            stamp_details = [
-                s for s in stamp_details
-                if s.accessMode == "shared"
-                or (s.accessMode is None and s.local)
-                or _is_owned_by(s.batchID, wallet)
-            ]
+            if exclusive:
+                # Only stamps purchased by this wallet
+                stamp_details = [
+                    s for s in stamp_details
+                    if _is_owned_by(s.batchID, wallet)
+                ]
+            else:
+                # Stamps accessible to this wallet (owned + shared + untracked local)
+                stamp_details = [
+                    s for s in stamp_details
+                    if s.accessMode == "shared"
+                    or (s.accessMode is None and s.local)
+                    or _is_owned_by(s.batchID, wallet)
+                ]
         else:
             # Default: local stamps only
             stamp_details = [s for s in stamp_details if s.local]

--- a/tests/test_stamp_list_filtering.py
+++ b/tests/test_stamp_list_filtering.py
@@ -155,6 +155,68 @@ class TestWalletFilteringX402Enabled:
         assert data["total_count"] == 0
 
 
+class TestExclusiveFiltering:
+    """?wallet=...&exclusive=true returns only stamps paid for by that wallet."""
+
+    WALLET = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12"
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_exclusive_returns_only_owned(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        def get_info(batch_id):
+            if batch_id == "c" * 64:
+                return {"owner": self.WALLET, "mode": "paid"}
+            if batch_id == "d" * 64:
+                return {"owner": "shared", "mode": "free"}
+            return None
+        mock_ownership.get_stamp_info.side_effect = get_info
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}&exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+
+        # Only the stamp owned by this wallet
+        assert "c" * 64 in batch_ids
+        # Shared stamp excluded
+        assert "d" * 64 not in batch_ids
+        # Untracked local stamp excluded
+        assert "a" * 64 not in batch_ids
+        assert data["total_count"] == 1
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_exclusive_empty_when_no_owned(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = [LOCAL_STAMP, SHARED_STAMP]
+        mock_ownership.get_stamp_info.return_value = None
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}&exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 0
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_exclusive_without_wallet_falls_to_default(self, mock_get, mock_settings):
+        """exclusive=true without wallet has no effect — falls to local-only default."""
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        # No wallet provided, so falls to default local-only
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        assert "b" * 64 not in batch_ids  # remote excluded
+        assert "a" * 64 in batch_ids  # local included
+
+
 class TestWalletFilteringX402Disabled:
     """?wallet param is ignored when x402 is disabled — falls back to local-only."""
 


### PR DESCRIPTION
## Summary

- Added `?exclusive=true` query parameter for `GET /api/v1/stamps/`
- When combined with `?wallet=0x...`, returns **only** stamps purchased by that wallet
- Excludes shared (free tier) and untracked stamps
- Without `exclusive`, wallet filtering still includes all accessible stamps

## Test plan

- [x] 3 new tests: exclusive returns only owned, empty when none owned, ignored without wallet
- [x] Full filtering test suite passes (19 tests)
- [ ] Verify staging: `?wallet=0x...&exclusive=true` returns only paid stamps