### PR TITLE
Merge dev to main: stamp ownership filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ python -m pytest tests/test_manifest_upload.py -v
 - Calculated `expectedExpiration` field in `YYYY-MM-DD-HH-MM` UTC format
 - Calculated `utilizationPercent` field showing stamp usage as percentage (0-100%)
 - Propagation timing fields: `secondsSincePurchase`, `estimatedReadyAt`, `propagationStatus`
+- Access control field: `accessMode` (`"owned"`, `"shared"`, or `null`)
 
 ### Environment Configuration
 
@@ -122,15 +123,22 @@ CORS (browser access):
 
 #### Stamp Management
 - `POST /api/v1/stamps/`: Purchase new postage stamps (records purchase time for propagation tracking)
-- `GET /api/v1/stamps/`: List all available stamps with expiration calculations and propagation status
+- `GET /api/v1/stamps/`: List stamps (default: local only). Supports `?global=true` for all stamps, `?wallet=0x...` for wallet-filtered view (x402)
 - `GET /api/v1/stamps/{stamp_id}`: Retrieve specific stamp batch details including propagation timing
 - `GET /api/v1/stamps/{stamp_id}/check`: Check stamp health for uploads (errors, warnings, can_upload status, propagation status)
 - `PATCH /api/v1/stamps/{stamp_id}/extend`: Extend existing stamps with additional funds
+
+**Stamp list query parameters**:
+- `global` (bool): If true, return all stamps including non-local (old behavior)
+- `wallet` (string): Filter to stamps accessible by this wallet address (requires x402 enabled)
 
 **Propagation timing fields** (included in all stamp responses):
 - `secondsSincePurchase`: Seconds elapsed since purchase through this gateway (null for external stamps)
 - `estimatedReadyAt`: ISO 8601 timestamp when stamp should be usable (null for external stamps)
 - `propagationStatus`: `"ready"` / `"propagating"` / `"unknown"` (null if undetermined)
+
+**Access mode field** (included in all stamp responses):
+- `accessMode`: `"owned"` (exclusive to a wallet via x402), `"shared"` (free tier), or `null` (not tracked)
 
 #### Data Operations
 - `POST /api/v1/data/?stamp_id={id}&content_type={type}&redundancy={level}`: Upload raw data to Swarm (redundancy 0-4, default 2)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ CORS (browser access):
 **Stamp list query parameters**:
 - `global` (bool): If true, return all stamps including non-local (old behavior)
 - `wallet` (string): Filter to stamps accessible by this wallet address (requires x402 enabled)
+- `exclusive` (bool): When used with `wallet`, return only stamps purchased by this wallet (excludes shared/free and untracked)
 
 **Propagation timing fields** (included in all stamp responses):
 - `secondsSincePurchase`: Seconds elapsed since purchase through this gateway (null for external stamps)

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Swarm Connect is a FastAPI-based API gateway that provides comprehensive access 
 
 #### Stamp Management
 - `POST /api/v1/stamps/`: Purchase new postage stamps with time-based or advanced parameters
-- `GET /api/v1/stamps/`: List all available stamps with expiration calculations
+- `GET /api/v1/stamps/`: List stamps (default: local only; `?global=true` for all; `?wallet=0x...` for wallet-filtered)
 - `GET /api/v1/stamps/{stamp_id}`: Retrieve specific stamp batch details
 - `GET /api/v1/stamps/{stamp_id}/check`: Check stamp health for uploads (errors and warnings)
 - `PATCH /api/v1/stamps/{stamp_id}/extend`: Extend existing stamps with additional funds
@@ -425,8 +425,16 @@ Purchase a new postage stamp with duration-based or legacy amount pricing.
 ```
 
 #### `GET /api/v1/stamps/`
-List all available postage stamps.
+List postage stamps. Default returns only local stamps (usable for uploads).
+
+**Query Parameters:**
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `global` | bool | `false` | If true, return all stamps including non-local |
+| `wallet` | string | - | Filter to stamps accessible by this wallet (requires x402 enabled) |
+
 - **Response**: `{"stamps": [...], "total_count": N}`
+- Each stamp includes `accessMode`: `"owned"` (exclusive), `"shared"` (free tier), or `null` (untracked)
 
 #### `GET /api/v1/stamps/{stamp_id}`
 Get detailed information about a specific stamp.

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ List postage stamps. Default returns only local stamps (usable for uploads).
 |-----------|------|---------|-------------|
 | `global` | bool | `false` | If true, return all stamps including non-local |
 | `wallet` | string | - | Filter to stamps accessible by this wallet (requires x402 enabled) |
+| `exclusive` | bool | `false` | With `wallet`: only stamps purchased by this wallet (excludes shared/untracked) |
 
 - **Response**: `{"stamps": [...], "total_count": N}`
 - Each stamp includes `accessMode`: `"owned"` (exclusive), `"shared"` (free tier), or `null` (untracked)

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -1,10 +1,11 @@
 # app/api/endpoints/stamps.py
-from fastapi import APIRouter, HTTPException, Path, Request, status, Body
-from typing import Any, Union
+from fastapi import APIRouter, HTTPException, Path, Query, Request, status, Body
+from typing import Any, Optional, Union
 import datetime
 from requests.exceptions import RequestException
 import logging
 
+from app.core.config import settings
 from app.services import swarm_api
 from app.services.stamp_ownership import stamp_ownership_manager
 from app.services.stamp_tracker import record_purchase
@@ -23,20 +24,43 @@ from app.api.models.stamp import (
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+def _is_owned_by(batch_id: str, wallet: str) -> bool:
+    """Check if a stamp is owned by the given wallet address."""
+    info = stamp_ownership_manager.get_stamp_info(batch_id)
+    if not info:
+        return False
+    return info.get("mode") == "paid" and info.get("owner") == wallet
+
+
 @router.get(
     "/",
     response_model=StampListResponse,
-    summary="List All Swarm Stamp Batches"
+    summary="List Swarm Stamp Batches"
 )
-async def list_stamps() -> Any:
+async def list_stamps(
+    wallet: Optional[str] = Query(
+        default=None,
+        description="Filter to stamps accessible by this wallet address (owned + shared + untracked local). Requires x402 to be enabled."
+    ),
+    global_view: Optional[bool] = Query(
+        default=None,
+        alias="global",
+        description="If true, return all stamps including non-local (old behavior)."
+    ),
+) -> Any:
     """
-    Retrieves a list of all postage stamp batches from the Swarm network.
+    Retrieves a list of postage stamp batches from the Swarm network.
 
-    Fetches all available stamp batches, processes them to calculate expiration times,
-    and returns a comprehensive list with stamp details.
+    **Default behavior**: Returns only **local** stamps (stamps owned by this Bee node).
+    This is the practical default since only local stamps can be used for uploads.
+
+    **Filtering options**:
+    - `?global=true` — Return all stamps visible on the network (old behavior)
+    - `?wallet=0xABC...` — Return stamps accessible by this wallet (owned + shared + untracked local).
+      Only effective when x402 is enabled; ignored otherwise.
 
     Returns:
-        StampListResponse: Contains list of all stamps and total count
+        StampListResponse: Contains list of filtered stamps and total count
 
     Raises:
         HTTPException: 502 if Swarm API is unreachable, 500 for other errors
@@ -53,6 +77,22 @@ async def list_stamps() -> Any:
             except Exception as e:
                 logger.warning(f"Skipping invalid stamp data: {e}")
                 continue
+
+        # Apply filtering
+        if global_view:
+            # No filtering — return everything (old behavior)
+            pass
+        elif wallet and settings.X402_ENABLED:
+            # Show stamps accessible to this wallet
+            stamp_details = [
+                s for s in stamp_details
+                if s.accessMode == "shared"
+                or (s.accessMode is None and s.local)
+                or _is_owned_by(s.batchID, wallet)
+            ]
+        else:
+            # Default: local stamps only
+            stamp_details = [s for s in stamp_details if s.local]
 
         return StampListResponse(
             stamps=stamp_details,
@@ -235,6 +275,7 @@ async def get_stamp_details(
             secondsSincePurchase=found_stamp.get("secondsSincePurchase"),
             estimatedReadyAt=found_stamp.get("estimatedReadyAt"),
             propagationStatus=found_stamp.get("propagationStatus"),
+            accessMode=found_stamp.get("accessMode"),
             expectedExpiration=found_stamp.get("expectedExpiration"),
             local=found_stamp.get("local")
         )

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -47,6 +47,10 @@ async def list_stamps(
         alias="global",
         description="If true, return all stamps including non-local (old behavior)."
     ),
+    exclusive: Optional[bool] = Query(
+        default=None,
+        description="When used with wallet, return only stamps purchased by this wallet (excludes shared and untracked stamps)."
+    ),
 ) -> Any:
     """
     Retrieves a list of postage stamp batches from the Swarm network.
@@ -58,6 +62,7 @@ async def list_stamps(
     - `?global=true` — Return all stamps visible on the network (old behavior)
     - `?wallet=0xABC...` — Return stamps accessible by this wallet (owned + shared + untracked local).
       Only effective when x402 is enabled; ignored otherwise.
+    - `?wallet=0xABC...&exclusive=true` — Return only stamps purchased by this wallet (excludes shared/free and untracked stamps).
 
     Returns:
         StampListResponse: Contains list of filtered stamps and total count
@@ -83,13 +88,20 @@ async def list_stamps(
             # No filtering — return everything (old behavior)
             pass
         elif wallet and settings.X402_ENABLED:
-            # Show stamps accessible to this wallet
-            stamp_details = [
-                s for s in stamp_details
-                if s.accessMode == "shared"
-                or (s.accessMode is None and s.local)
-                or _is_owned_by(s.batchID, wallet)
-            ]
+            if exclusive:
+                # Only stamps purchased by this wallet
+                stamp_details = [
+                    s for s in stamp_details
+                    if _is_owned_by(s.batchID, wallet)
+                ]
+            else:
+                # Stamps accessible to this wallet (owned + shared + untracked local)
+                stamp_details = [
+                    s for s in stamp_details
+                    if s.accessMode == "shared"
+                    or (s.accessMode is None and s.local)
+                    or _is_owned_by(s.batchID, wallet)
+                ]
         else:
             # Default: local stamps only
             stamp_details = [s for s in stamp_details if s.local]

--- a/app/api/models/stamp.py
+++ b/app/api/models/stamp.py
@@ -50,6 +50,12 @@ class StampDetails(BaseModel):
         description="Propagation status: 'ready' (usable), 'propagating' (waiting for network), 'unknown' (not tracked by this gateway). Null if status cannot be determined."
     )
 
+    # --- Access Control Fields ---
+    accessMode: Optional[Literal["owned", "shared"]] = Field(
+        None,
+        description="Access mode: 'owned' (exclusive to a wallet via x402 payment), 'shared' (free tier, anyone can use), null (not in ownership registry)."
+    )
+
     # --- Calculated Fields ---
     expectedExpiration: str = Field(..., description="Calculated expiration timestamp (YYYY-MM-DD-HH-MM UTC).")
     local: bool = Field(..., description="Indicates if this stamp is owned/managed by the local node.")
@@ -75,6 +81,7 @@ class StampDetails(BaseModel):
                 "secondsSincePurchase": None,
                 "estimatedReadyAt": None,
                 "propagationStatus": "ready",
+                "accessMode": None,
                 "expectedExpiration": "2024-08-15-10-30",
                 "local": True
             }
@@ -229,6 +236,7 @@ class StampListResponse(BaseModel):
                         "secondsSincePurchase": None,
                         "estimatedReadyAt": None,
                         "propagationStatus": "ready",
+                        "accessMode": None,
                         "expectedExpiration": "2024-08-15-10-30",
                         "local": False
                     }

--- a/app/services/swarm_api.py
+++ b/app/services/swarm_api.py
@@ -7,6 +7,7 @@ from typing import List, Dict, Any, Optional
 from urllib.parse import urljoin
 
 from app.core.config import settings
+from app.services.stamp_ownership import stamp_ownership_manager
 
 logger = logging.getLogger(__name__)
 
@@ -495,6 +496,13 @@ def get_all_stamps_processed() -> List[Dict[str, Any]]:
             # Calculate propagation signals
             propagation = calculate_propagation_signals(batch_id, usable)
 
+            # Determine access mode from ownership registry
+            ownership_info = stamp_ownership_manager.get_stamp_info(batch_id)
+            if ownership_info:
+                access_mode = "owned" if ownership_info.get("mode") == "paid" else "shared"
+            else:
+                access_mode = None
+
             # Create processed stamp data
             processed_stamp = {
                 "batchID": batch_id,
@@ -515,6 +523,7 @@ def get_all_stamps_processed() -> List[Dict[str, Any]]:
                 "batchTTL": batch_ttl,
                 "exists": merged_stamp.get("exists", True),
                 "owner": merged_stamp.get("owner"),  # New field from local data
+                "accessMode": access_mode,
                 "expectedExpiration": expiration_str,
                 "local": local_stamp is not None  # True if stamp found in local data
             }

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -327,7 +327,7 @@ class TestFieldConsistency:
 
         mock_get_stamps.return_value = [minimal_stamp_data]
 
-        response = client.get("/api/v1/stamps/")
+        response = client.get("/api/v1/stamps/?global=true")
         assert response.status_code == 200
 
         stamp = response.json()["stamps"][0]
@@ -395,7 +395,7 @@ class TestExpirationCalculation:
 
             mock_get_stamps.return_value = [full_stamp]
 
-            response = client.get("/api/v1/stamps/")
+            response = client.get("/api/v1/stamps/?global=true")
             assert response.status_code == 200
 
             stamp = response.json()["stamps"][0]

--- a/tests/test_stamp_list_filtering.py
+++ b/tests/test_stamp_list_filtering.py
@@ -1,0 +1,310 @@
+# tests/test_stamp_list_filtering.py
+"""Tests for GET /api/v1/stamps/ ownership filtering and accessMode field."""
+import pytest
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def _make_stamp(batch_id, local=True, access_mode=None):
+    """Helper to create a processed stamp dict."""
+    return {
+        "batchID": batch_id,
+        "amount": "1000000000",
+        "blockNumber": 12345,
+        "owner": "0x1234567890abcdef",
+        "immutableFlag": False,
+        "depth": 20,
+        "bucketDepth": 16,
+        "batchTTL": 86400,
+        "utilization": None,
+        "utilizationPercent": None,
+        "utilizationStatus": None,
+        "utilizationWarning": None,
+        "usable": True,
+        "label": None,
+        "secondsSincePurchase": None,
+        "estimatedReadyAt": None,
+        "propagationStatus": "ready",
+        "accessMode": access_mode,
+        "expectedExpiration": "2026-12-01-15-30",
+        "local": local,
+    }
+
+
+LOCAL_STAMP = _make_stamp("a" * 64, local=True, access_mode=None)
+REMOTE_STAMP = _make_stamp("b" * 64, local=False, access_mode=None)
+OWNED_STAMP = _make_stamp("c" * 64, local=True, access_mode="owned")
+SHARED_STAMP = _make_stamp("d" * 64, local=True, access_mode="shared")
+REMOTE_OWNED = _make_stamp("e" * 64, local=False, access_mode="owned")
+
+ALL_STAMPS = [LOCAL_STAMP, REMOTE_STAMP, OWNED_STAMP, SHARED_STAMP, REMOTE_OWNED]
+
+
+class TestDefaultBehavior:
+    """Default (no params) returns only local stamps."""
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_default_returns_local_only(self, mock_get):
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/")
+        assert response.status_code == 200
+        data = response.json()
+
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        # LOCAL_STAMP, OWNED_STAMP, SHARED_STAMP are local=True
+        assert "a" * 64 in batch_ids
+        assert "c" * 64 in batch_ids
+        assert "d" * 64 in batch_ids
+        # REMOTE_STAMP and REMOTE_OWNED are local=False
+        assert "b" * 64 not in batch_ids
+        assert "e" * 64 not in batch_ids
+        assert data["total_count"] == 3
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_default_empty_when_no_local(self, mock_get):
+        mock_get.return_value = [REMOTE_STAMP]
+
+        response = client.get("/api/v1/stamps/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["stamps"] == []
+        assert data["total_count"] == 0
+
+
+class TestGlobalView:
+    """?global=true returns all stamps (old behavior)."""
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_global_returns_all(self, mock_get):
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?global=true")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == len(ALL_STAMPS)
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_global_false_acts_as_default(self, mock_get):
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?global=false")
+        assert response.status_code == 200
+        data = response.json()
+        # global=false is falsy, falls to default (local only)
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        assert "b" * 64 not in batch_ids
+
+
+class TestWalletFilteringX402Enabled:
+    """?wallet=0x... with x402 enabled filters to accessible stamps."""
+
+    WALLET = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12"
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_wallet_shows_owned_shared_untracked(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        # c*64 is owned by WALLET, e*64 is owned by someone else
+        def get_info(batch_id):
+            if batch_id == "c" * 64:
+                return {"owner": self.WALLET, "mode": "paid"}
+            if batch_id == "e" * 64:
+                return {"owner": "0xOTHER", "mode": "paid"}
+            if batch_id == "d" * 64:
+                return {"owner": "shared", "mode": "free"}
+            return None
+        mock_ownership.get_stamp_info.side_effect = get_info
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}")
+        assert response.status_code == 200
+        data = response.json()
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+
+        # LOCAL_STAMP: accessMode=None, local=True → included (untracked local)
+        assert "a" * 64 in batch_ids
+        # SHARED_STAMP: accessMode="shared" → included
+        assert "d" * 64 in batch_ids
+        # OWNED_STAMP: owned by this wallet → included
+        assert "c" * 64 in batch_ids
+        # REMOTE_STAMP: accessMode=None, local=False → excluded
+        assert "b" * 64 not in batch_ids
+        # REMOTE_OWNED: owned by someone else → excluded
+        assert "e" * 64 not in batch_ids
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_wallet_excludes_other_wallets_stamps(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        owned_by_other = _make_stamp("f" * 64, local=True, access_mode="owned")
+        mock_get.return_value = [owned_by_other]
+
+        mock_ownership.get_stamp_info.return_value = {"owner": "0xOTHER", "mode": "paid"}
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 0
+
+
+class TestWalletFilteringX402Disabled:
+    """?wallet param is ignored when x402 is disabled — falls back to local-only."""
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_wallet_ignored_when_x402_disabled(self, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = False
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?wallet=0xABC")
+        assert response.status_code == 200
+        data = response.json()
+        # Falls back to default local-only filtering
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        assert "b" * 64 not in batch_ids  # remote
+        assert "a" * 64 in batch_ids  # local
+
+
+class TestAccessModeField:
+    """accessMode field is correctly populated in responses."""
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_access_mode_values(self, mock_get):
+        mock_get.return_value = [LOCAL_STAMP, OWNED_STAMP, SHARED_STAMP]
+
+        response = client.get("/api/v1/stamps/")
+        assert response.status_code == 200
+        data = response.json()
+
+        modes = {s["batchID"]: s["accessMode"] for s in data["stamps"]}
+        assert modes["a" * 64] is None
+        assert modes["c" * 64] == "owned"
+        assert modes["d" * 64] == "shared"
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_access_mode_in_stamp_detail(self, mock_get):
+        """accessMode appears in GET /stamps/{id} response too."""
+        mock_get.return_value = [OWNED_STAMP]
+
+        response = client.get(f"/api/v1/stamps/{'c' * 64}")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["accessMode"] == "owned"
+
+
+class TestParameterPrecedence:
+    """When both global and wallet are provided, global wins."""
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_global_true_overrides_wallet(self, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?global=true&wallet=0xABC")
+        assert response.status_code == 200
+        data = response.json()
+        # global=true wins — all stamps returned
+        assert data["total_count"] == len(ALL_STAMPS)
+
+
+class TestIsOwnedByEdgeCases:
+    """Edge cases for the _is_owned_by helper."""
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_free_mode_stamp_not_treated_as_owned(self, mock_ownership, mock_get, mock_settings):
+        """A stamp with mode=free should not match _is_owned_by even if owner field matches."""
+        mock_settings.X402_ENABLED = True
+        # Stamp has accessMode="shared" (from the processed data),
+        # but let's test a stamp with accessMode="owned" that actually has mode=free in registry
+        stamp = _make_stamp("f" * 64, local=True, access_mode="owned")
+        mock_get.return_value = [stamp]
+
+        # Registry says mode=free (not paid), so _is_owned_by should return False
+        mock_ownership.get_stamp_info.return_value = {"owner": "0xWALLET", "mode": "free"}
+
+        response = client.get("/api/v1/stamps/?wallet=0xWALLET")
+        data = response.json()
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        # accessMode="owned" but registry mode=free → _is_owned_by returns False
+        # accessMode is not "shared" and not None → excluded
+        assert "f" * 64 not in batch_ids
+
+
+class TestAccessModeServiceLayer:
+    """Test accessMode population at the service layer."""
+
+    @patch("app.services.swarm_api.stamp_ownership_manager")
+    @patch("app.services.swarm_api.get_local_stamps")
+    @patch("app.services.swarm_api.get_all_stamps")
+    def test_access_mode_paid_becomes_owned(self, mock_global, mock_local, mock_ownership):
+        mock_global.return_value = [{
+            "batchID": "a" * 64, "amount": "1000", "depth": 20,
+            "bucketDepth": 16, "batchTTL": 86400,
+        }]
+        mock_local.return_value = []
+        mock_ownership.get_stamp_info.return_value = {"mode": "paid", "owner": "0xABC"}
+
+        from app.services.swarm_api import get_all_stamps_processed
+        result = get_all_stamps_processed()
+        assert result[0]["accessMode"] == "owned"
+
+    @patch("app.services.swarm_api.stamp_ownership_manager")
+    @patch("app.services.swarm_api.get_local_stamps")
+    @patch("app.services.swarm_api.get_all_stamps")
+    def test_access_mode_free_becomes_shared(self, mock_global, mock_local, mock_ownership):
+        mock_global.return_value = [{
+            "batchID": "b" * 64, "amount": "1000", "depth": 20,
+            "bucketDepth": 16, "batchTTL": 86400,
+        }]
+        mock_local.return_value = []
+        mock_ownership.get_stamp_info.return_value = {"mode": "free", "owner": "shared"}
+
+        from app.services.swarm_api import get_all_stamps_processed
+        result = get_all_stamps_processed()
+        assert result[0]["accessMode"] == "shared"
+
+    @patch("app.services.swarm_api.stamp_ownership_manager")
+    @patch("app.services.swarm_api.get_local_stamps")
+    @patch("app.services.swarm_api.get_all_stamps")
+    def test_access_mode_untracked_is_none(self, mock_global, mock_local, mock_ownership):
+        mock_global.return_value = [{
+            "batchID": "c" * 64, "amount": "1000", "depth": 20,
+            "bucketDepth": 16, "batchTTL": 86400,
+        }]
+        mock_local.return_value = []
+        mock_ownership.get_stamp_info.return_value = None
+
+        from app.services.swarm_api import get_all_stamps_processed
+        result = get_all_stamps_processed()
+        assert result[0]["accessMode"] is None
+
+
+class TestTotalCountAccuracy:
+    """total_count reflects the filtered result, not all stamps."""
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_total_count_matches_filtered(self, mock_get):
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/")
+        data = response.json()
+        assert data["total_count"] == len(data["stamps"])
+
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_total_count_global(self, mock_get):
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?global=true")
+        data = response.json()
+        assert data["total_count"] == len(ALL_STAMPS)

--- a/tests/test_stamp_list_filtering.py
+++ b/tests/test_stamp_list_filtering.py
@@ -155,6 +155,68 @@ class TestWalletFilteringX402Enabled:
         assert data["total_count"] == 0
 
 
+class TestExclusiveFiltering:
+    """?wallet=...&exclusive=true returns only stamps paid for by that wallet."""
+
+    WALLET = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12"
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_exclusive_returns_only_owned(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        def get_info(batch_id):
+            if batch_id == "c" * 64:
+                return {"owner": self.WALLET, "mode": "paid"}
+            if batch_id == "d" * 64:
+                return {"owner": "shared", "mode": "free"}
+            return None
+        mock_ownership.get_stamp_info.side_effect = get_info
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}&exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+
+        # Only the stamp owned by this wallet
+        assert "c" * 64 in batch_ids
+        # Shared stamp excluded
+        assert "d" * 64 not in batch_ids
+        # Untracked local stamp excluded
+        assert "a" * 64 not in batch_ids
+        assert data["total_count"] == 1
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    @patch("app.api.endpoints.stamps.stamp_ownership_manager")
+    def test_exclusive_empty_when_no_owned(self, mock_ownership, mock_get, mock_settings):
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = [LOCAL_STAMP, SHARED_STAMP]
+        mock_ownership.get_stamp_info.return_value = None
+
+        response = client.get(f"/api/v1/stamps/?wallet={self.WALLET}&exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 0
+
+    @patch("app.api.endpoints.stamps.settings")
+    @patch("app.services.swarm_api.get_all_stamps_processed")
+    def test_exclusive_without_wallet_falls_to_default(self, mock_get, mock_settings):
+        """exclusive=true without wallet has no effect — falls to local-only default."""
+        mock_settings.X402_ENABLED = True
+        mock_get.return_value = ALL_STAMPS
+
+        response = client.get("/api/v1/stamps/?exclusive=true")
+        assert response.status_code == 200
+        data = response.json()
+        # No wallet provided, so falls to default local-only
+        batch_ids = {s["batchID"] for s in data["stamps"]}
+        assert "b" * 64 not in batch_ids  # remote excluded
+        assert "a" * 64 in batch_ids  # local included
+
+
 class TestWalletFilteringX402Disabled:
     """?wallet param is ignored when x402 is disabled — falls back to local-only."""
 

--- a/tests/test_stamps_api.py
+++ b/tests/test_stamps_api.py
@@ -20,7 +20,7 @@ class TestStampsAPI:
 
     @patch('app.services.swarm_api.get_all_stamps_processed')
     def test_list_stamps_success(self, mock_get_stamps):
-        """Test successful retrieval of stamps list."""
+        """Test successful retrieval of stamps list (default: local only)."""
         mock_get_stamps.return_value = [
             {
                 "batchID": "test123",
@@ -54,13 +54,14 @@ class TestStampsAPI:
             }
         ]
 
+        # Default: only local stamps returned
         response = client.get("/api/v1/stamps/")
 
         assert response.status_code == 200
         data = response.json()
 
-        assert data["total_count"] == 2
-        assert len(data["stamps"]) == 2
+        assert data["total_count"] == 1
+        assert len(data["stamps"]) == 1
 
         # Check first stamp (local)
         stamp1 = data["stamps"][0]
@@ -70,8 +71,12 @@ class TestStampsAPI:
         assert stamp1["label"] == "test-stamp"
         assert stamp1["immutableFlag"] is False
 
-        # Check second stamp (global only)
-        stamp2 = data["stamps"][1]
+        # Use ?global=true to get all stamps (old behavior)
+        response_global = client.get("/api/v1/stamps/?global=true")
+        data_global = response_global.json()
+        assert data_global["total_count"] == 2
+        assert len(data_global["stamps"]) == 2
+        stamp2 = data_global["stamps"][1]
         assert stamp2["batchID"] == "test456"
         assert stamp2["local"] is False
         assert stamp2["utilization"] is None


### PR DESCRIPTION
## Summary

- Default `GET /api/v1/stamps/` now returns local stamps only
- Added `?global=true`, `?wallet=0x...`, and `?exclusive=true` query parameters
- Added `accessMode` field to stamp responses
- Verified on staging

## PRs included

- #142 Add ownership filtering to GET /api/v1/stamps/
- #143 Add exclusive parameter to wallet stamp filtering