### PR TITLE
Fix missing await in x402 payment dependency

### DIFF
--- a/app/x402/dependency.py
+++ b/app/x402/dependency.py
@@ -47,7 +47,7 @@ def _get_facilitator_client() -> FacilitatorClient:
     return _facilitator_client
 
 
-def _calculate_price_for_request(request: Request) -> dict:
+async def _calculate_price_for_request(request: Request) -> dict:
     """
     Calculate price based on the request type.
 
@@ -57,7 +57,7 @@ def _calculate_price_for_request(request: Request) -> dict:
     path = request.url.path
 
     if "/stamps/" in path:
-        quote = get_price_quote(
+        quote = await get_price_quote(
             operation="stamp_purchase",
             duration_hours=24,
             depth=17
@@ -71,7 +71,7 @@ def _calculate_price_for_request(request: Request) -> dict:
         content_length = request.headers.get("Content-Length", "0")
         size_bytes = int(content_length) if content_length.isdigit() else 1024
 
-        quote = get_price_quote(
+        quote = await get_price_quote(
             operation="upload",
             size_bytes=size_bytes,
             duration_hours=24
@@ -108,7 +108,7 @@ async def require_x402_payment(request: Request) -> None:
         return
 
     # Check gateway ETH balance
-    base_balance = check_base_eth_balance()
+    base_balance = await check_base_eth_balance()
     if base_balance.get("is_critical"):
         logger.error(
             f"x402: Gateway ETH critically low ({base_balance.get('balance_eth', 0):.6f} ETH). "
@@ -129,7 +129,7 @@ async def require_x402_payment(request: Request) -> None:
 
     # Calculate price for this operation
     try:
-        price_quote = _calculate_price_for_request(request)
+        price_quote = await _calculate_price_for_request(request)
         price_usd = price_quote["price_usd"]
         description = price_quote.get("description", "Gateway operation")
     except Exception as e:

--- a/app/x402/pricing.py
+++ b/app/x402/pricing.py
@@ -79,7 +79,7 @@ def apply_minimum_price(price: float, minimum: Optional[float] = None) -> float:
     return max(price, min_price)
 
 
-def calculate_stamp_price_usd(
+async def calculate_stamp_price_usd(
     duration_hours: int,
     depth: int = 17,
     include_breakdown: bool = True
@@ -113,7 +113,7 @@ def calculate_stamp_price_usd(
         Exception: If unable to fetch chainstate from Bee node
     """
     # Get current price from chainstate
-    chainstate = get_chainstate()
+    chainstate = await get_chainstate()
     current_price = int(chainstate.get("currentPrice", 0))
 
     if current_price <= 0:
@@ -172,7 +172,7 @@ def calculate_stamp_price_usd(
     return result
 
 
-def calculate_upload_price_usd(
+async def calculate_upload_price_usd(
     size_bytes: int,
     duration_hours: int = 24,
     include_breakdown: bool = True
@@ -216,7 +216,7 @@ def calculate_upload_price_usd(
         depth += 1
 
     # Calculate stamp price for this depth and duration
-    stamp_price = calculate_stamp_price_usd(
+    stamp_price = await calculate_stamp_price_usd(
         duration_hours=duration_hours,
         depth=depth,
         include_breakdown=include_breakdown
@@ -248,7 +248,7 @@ def calculate_upload_price_usd(
     return result
 
 
-def get_price_quote(
+async def get_price_quote(
     operation: str,
     **kwargs
 ) -> Dict[str, Any]:
@@ -276,11 +276,11 @@ def get_price_quote(
     if operation == "stamp_purchase":
         duration_hours = kwargs.get("duration_hours", 24)
         depth = kwargs.get("depth", 17)
-        price_info = calculate_stamp_price_usd(duration_hours, depth)
+        price_info = await calculate_stamp_price_usd(duration_hours, depth)
     elif operation == "upload":
         size_bytes = kwargs.get("size_bytes", 0)
         duration_hours = kwargs.get("duration_hours", 24)
-        price_info = calculate_upload_price_usd(size_bytes, duration_hours)
+        price_info = await calculate_upload_price_usd(size_bytes, duration_hours)
     else:
         raise ValueError(f"Unknown operation type: {operation}")
 


### PR DESCRIPTION
## Summary

- Fix missing `await` for `check_base_eth_balance()` in `app/x402/dependency.py` — the function became async in the httpx migration (#159) but this call site was missed
- Fix missing `await` for `get_chainstate()` in `app/x402/pricing.py` — same issue, `get_chainstate()` is now async
- Convert `calculate_stamp_price_usd`, `calculate_upload_price_usd`, `get_price_quote`, and `_calculate_price_for_request` to async functions to support the awaited calls

## Root Cause

POST requests to protected endpoints (stamps, data upload) were returning 500 errors on staging because the x402 dependency called `check_base_eth_balance()` and pricing called `get_chainstate()` without `await`. Both functions were converted to async in #159 but these call sites in the x402 module were missed, causing coroutine objects to be used instead of resolved values.

## Test plan

- [x] All 561 tests pass locally
- [ ] Deploy to staging, verify `POST /api/v1/data/` returns proper response instead of 500