### PR TITLE
Add Grafana Alloy container for metrics push to Grafana Cloud

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,8 +102,13 @@ jobs:
           EOF
 
       - name: deploy
-        run: >
-          cd /opt/ && rm -rf swarm_connect && git clone -b $GITHUB_REF_NAME https://github.com/datafund/swarm_connect.git && cd swarm_connect && docker compose up -d
+        run: |
+          cd /opt/ && rm -rf swarm_connect && git clone -b $GITHUB_REF_NAME https://github.com/datafund/swarm_connect.git && cd swarm_connect
+          cat > .env << EOF
+          GRAFANA_CLOUD_PROM_USERNAME=${{ secrets.GRAFANA_CLOUD_PROM_USERNAME }}
+          GRAFANA_CLOUD_API_TOKEN=${{ secrets.GRAFANA_CLOUD_API_TOKEN }}
+          EOF
+          docker compose up -d --force-recreate
 
       - name: post-deploy diagnostics
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,15 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+    environment:
+      - GRAFANA_CLOUD_PROM_USERNAME=${GRAFANA_CLOUD_PROM_USERNAME}
+      - GRAFANA_CLOUD_API_TOKEN=${GRAFANA_CLOUD_API_TOKEN}
+    command: ["run", "/etc/alloy/config.alloy"]
+    restart: unless-stopped
+    depends_on:
+      - provenance_gateway_dev

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,0 +1,51 @@
+// Grafana Alloy configuration for Provenance Gateway monitoring
+// Scrapes /metrics from gateway containers and pushes to Grafana Cloud
+
+// ── Scrape staging gateway ──────────────────────────────────────────────────
+
+prometheus.scrape "staging" {
+  targets = [{"__address__" = "provenance_gateway_dev:8000"}]
+  metrics_path = "/metrics"
+  scrape_interval = "15s"
+  forward_to = [prometheus.relabel.add_environment_staging.receiver]
+}
+
+prometheus.relabel "add_environment_staging" {
+  rule {
+    action       = "replace"
+    target_label = "environment"
+    replacement  = "staging"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Scrape production gateway ───────────────────────────────────────────────
+
+prometheus.scrape "production" {
+  targets = [{"__address__" = "provenance_gateway:8000"}]
+  metrics_path = "/metrics"
+  scrape_interval = "15s"
+  forward_to = [prometheus.relabel.add_environment_production.receiver]
+}
+
+prometheus.relabel "add_environment_production" {
+  rule {
+    action       = "replace"
+    target_label = "environment"
+    replacement  = "production"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Push to Grafana Cloud ───────────────────────────────────────────────────
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"
+
+    basic_auth {
+      username = env("GRAFANA_CLOUD_PROM_USERNAME")
+      password = env("GRAFANA_CLOUD_API_TOKEN")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add Grafana Alloy as a Docker service in `docker-compose.yml`
- Alloy scrapes `/metrics` from both gateway containers (staging + production) every 15s
- Pushes metrics to Grafana Cloud Prometheus via remote write
- Credentials stored in GitHub secrets (`GRAFANA_CLOUD_PROM_USERNAME`, `GRAFANA_CLOUD_API_TOKEN`), injected via `.env` file at deploy time
- Dashboard already pushed to `datafund.grafana.net/d/gateway-overview`

## How it works

```
Gateway containers ──/metrics──> Alloy ──remote write──> Grafana Cloud
  (port 8000)                   (same Docker network)    (Prometheus + dashboards)
```

Alloy runs on the same Docker network, scrapes the gateway containers by service name, and adds `environment=staging` or `environment=production` labels.

## Files

- `monitoring/alloy/config.alloy` — Alloy scrape + remote write config
- `docker-compose.yml` — new `alloy` service
- `.github/workflows/deploy.yml` — writes Grafana credentials to `.env` at deploy

## Addresses

- #185 (Grafana Cloud + Alloy setup)

## Test plan

- [ ] Merge to dev → auto-deploy → verify Alloy container is running
- [ ] Check `datafund.grafana.net` Explore → query `gateway_info{environment="staging"}`
- [ ] Verify dashboard panels populate with staging data