### PR TITLE
Fix pool metrics, add dashboard descriptions, update monitoring docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,30 @@ The gateway exposes a `/metrics` endpoint (Prometheus text format) when `METRICS
 
 **Info**: `gateway_info{version, environment, x402_enabled, pool_enabled, notary_enabled}`
 
+### Production Monitoring Stack
+
+```
+Gateway containers ──/metrics──> Alloy ──remote write──> Grafana Cloud
+  (port 8000)                   (Docker)                 (dashboards + alerts)
+```
+
+**How it works:**
+- Grafana Alloy runs as a Docker container alongside the gateways (`docker-compose.yml`)
+- Alloy scrapes `/metrics` from both gateway containers every 15s via Docker network
+- Alloy pushes metrics to Grafana Cloud Prometheus (remote write)
+- Grafana Cloud stores metrics (14-day retention) and hosts dashboards
+- Environment labels: `development` (dev branch) and `main` (main branch)
+
+**Credentials** (stored in GitHub secrets, injected at deploy):
+- `GRAFANA_CLOUD_PROM_USERNAME` — Prometheus instance ID
+- `GRAFANA_CLOUD_API_TOKEN` — API token with `metrics:write` scope
+
+**Dashboard:** `datafund.grafana.net/d/gateway-overview`
+
+**Key files:**
+- `monitoring/alloy/config.alloy` — Alloy scrape + remote write config
+- `monitoring/provisioning/dashboards/gateway-overview.json` — dashboard JSON (pushed to Grafana Cloud via API)
+
 ### Local Monitoring Stack
 
 A local Prometheus + Grafana setup is in `monitoring/` for development:
@@ -375,6 +399,11 @@ docker compose -f monitoring/docker-compose.monitoring.yml up -d
 # - Gateway metrics: http://localhost:8000/metrics
 # - Prometheus:      http://localhost:9090
 # - Grafana:         http://localhost:3000 (admin/admin)
+
+# Push dashboard to local Grafana
+curl -X POST http://admin:admin@localhost:3000/api/dashboards/db \
+  -H "Content-Type: application/json" \
+  -d @monitoring/provisioning/dashboards/gateway-overview.json
 
 # Stop
 docker compose -f monitoring/docker-compose.monitoring.yml down

--- a/README.md
+++ b/README.md
@@ -382,25 +382,51 @@ See [x402 Operator Guide](docs/x402-operator-guide.md) for complete setup instru
 
 ## Monitoring
 
-The gateway exposes a Prometheus metrics endpoint at `GET /metrics` for operational monitoring.
+The gateway has built-in Prometheus monitoring with a Grafana Cloud dashboard.
+
+**Architecture:**
+```
+Gateway ──/metrics──> Grafana Alloy ──remote write──> Grafana Cloud
+                      (Docker)                        (dashboards + alerts)
+```
+
+- Gateway exposes `GET /metrics` with Prometheus text format
+- [Grafana Alloy](https://grafana.com/docs/alloy/) runs as a sidecar container, scrapes metrics every 15s
+- Metrics are pushed to Grafana Cloud (free tier: 10k series, 14-day retention)
+- Dashboard: [datafund.grafana.net/d/gateway-overview](https://datafund.grafana.net/d/gateway-overview)
 
 **What's tracked:**
-- HTTP request rate, latency, and error rate (auto-instrumented)
+- HTTP request rate, latency percentiles (p50/p95/p99), and error rate
 - Upload/download counts and bytes transferred
 - Stamp purchases and pool acquisitions
-- Wallet balances (BZZ, xDAI, chequebook, Base ETH)
-- Stamp pool availability and TTL
-- x402 payment mode breakdown
+- Wallet balances (BZZ, xDAI, chequebook, Base ETH) with alert thresholds
+- Stamp pool availability by size and minimum TTL
+- x402 payment mode breakdown (paid/free/rejected)
+- Bee node API error rate by endpoint
 - Rate limit rejections
 
 **Configuration:**
 ```bash
 METRICS_ENABLED=true                # Expose /metrics (default: true)
 METRICS_BALANCE_POLL_SECONDS=60     # Balance polling interval (default: 60s)
-GATEWAY_ENVIRONMENT=production      # Environment label for multi-instance setups
+GATEWAY_ENVIRONMENT=development     # Environment label: development or main
 ```
 
-**Stack:** Prometheus + Grafana Cloud + Telegram alerting. See the [monitoring epic](https://github.com/datafund/swarm_connect/issues/179) for setup details.
+**Local development:**
+```bash
+# Run local Prometheus + Grafana
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+# Prometheus: http://localhost:9090
+# Grafana:    http://localhost:3000 (admin/admin)
+```
+
+**Grafana Cloud setup** (for new deployments):
+1. Create a [Grafana Cloud](https://grafana.com/products/cloud/) account (free tier)
+2. Create an access policy with `metrics:write` scope, generate a token
+3. Set GitHub secrets: `GRAFANA_CLOUD_PROM_USERNAME` (instance ID) and `GRAFANA_CLOUD_API_TOKEN`
+4. Alloy deploys automatically via `docker-compose.yml` on next push
+
+See the [monitoring epic](https://github.com/datafund/swarm_connect/issues/179) for full details.
 
 ## API Endpoints
 

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -146,15 +146,16 @@ async def _poll_balances():
             if settings.STAMP_POOL_ENABLED:
                 try:
                     from app.services.stamp_pool import stamp_pool_manager
+                    DEPTH_TO_SIZE = {17: "small", 20: "medium", 22: "large"}
                     status = stamp_pool_manager.get_status()
-                    reserves = status.get("reserves", {})
-                    for size_name, info in reserves.items():
+                    current_levels = status.get("current_levels", {})
+                    reserve_config = status.get("reserve_config", {})
+                    for depth, target in reserve_config.items():
+                        size_name = DEPTH_TO_SIZE.get(int(depth), f"depth-{depth}")
                         stamp_pool_available.labels(size=size_name).set(
-                            info.get("available", 0)
+                            current_levels.get(int(depth), 0)
                         )
-                        stamp_pool_target.labels(size=size_name).set(
-                            info.get("target", 0)
-                        )
+                        stamp_pool_target.labels(size=size_name).set(target)
                 except Exception as e:
                     logger.debug(f"Metrics: failed to get pool status: {e}")
 

--- a/monitoring/provisioning/dashboards/gateway-overview.json
+++ b/monitoring/provisioning/dashboards/gateway-overview.json
@@ -3,13 +3,11 @@
     "id": null,
     "uid": "gateway-overview",
     "title": "Provenance Gateway Overview",
+    "description": "Operational dashboard for the Provenance Gateway (swarm_connect). Shows request traffic, latency, wallet balances, stamp pool status, x402 payments, and Bee node health. Use the Environment dropdown to filter by deployment (development/main).",
     "tags": ["gateway", "provenance"],
     "timezone": "browser",
     "refresh": "15s",
-    "time": {
-      "from": "now-1h",
-      "to": "now"
-    },
+    "time": { "from": "now-1h", "to": "now" },
     "templating": {
       "list": [
         {
@@ -29,539 +27,158 @@
     },
     "panels": [
       {
-        "id": 1,
-        "title": "Gateway Status",
-        "type": "stat",
+        "id": 1, "title": "Gateway Status", "type": "stat",
+        "description": "Whether the gateway process is up and responding to /metrics scrapes. GREEN = up, RED = down.",
         "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-        "targets": [
-          {
-            "expr": "up{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "mappings": [
-              { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "up{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }], "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "green" }] } } }
       },
       {
-        "id": 2,
-        "title": "Uptime",
-        "type": "stat",
+        "id": 2, "title": "Uptime", "type": "stat",
+        "description": "How long the gateway process has been running since last restart. Resets on deploy.",
         "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-        "targets": [
-          {
-            "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "h",
-            "decimals": 1,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "h", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }] } } }
       },
       {
-        "id": 3,
-        "title": "Request Rate",
-        "type": "stat",
+        "id": 3, "title": "Request Rate", "type": "stat",
+        "description": "Total HTTP requests per second across all endpoints (5-minute average).",
         "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(rate(http_requests_total{environment=~\"$environment\"}[5m]))",
-            "legendFormat": "req/s"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "decimals": 2,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "blue" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(http_requests_total{environment=~\"$environment\"}[5m]))", "legendFormat": "req/s" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "blue" }] } } }
       },
       {
-        "id": 4,
-        "title": "Error Rate",
-        "type": "stat",
+        "id": 4, "title": "Error Rate", "type": "stat",
+        "description": "Percentage of requests returning 5xx errors (5-minute average). >1% = warning, >5% = critical.",
         "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=~\"$environment\"}[5m])) * 100 or vector(0)",
-            "legendFormat": "5xx %"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "percent",
-            "decimals": 1,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "green" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "red" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=~\"$environment\"}[5m])) * 100 or vector(0)", "legendFormat": "5xx %" }],
+        "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "red" }] } } }
       },
       {
-        "id": 5,
-        "title": "Total Uploads",
-        "type": "stat",
+        "id": 5, "title": "Total Uploads", "type": "stat",
+        "description": "Total successful data uploads (POST /api/v1/data/) since last gateway restart.",
         "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
-            "legendFormat": "uploads"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "purple" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "uploads" }],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "purple" }] } } }
       },
       {
-        "id": 6,
-        "title": "Total Downloads",
-        "type": "stat",
+        "id": 6, "title": "Total Downloads", "type": "stat",
+        "description": "Total successful data downloads (GET /api/v1/data/{ref}) since last gateway restart.",
         "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
-            "legendFormat": "downloads"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "blue" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "downloads" }],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "blue" }] } } }
       },
       {
-        "id": 10,
-        "title": "Request Rate by Endpoint",
-        "type": "timeseries",
+        "id": 10, "title": "Request Rate by Endpoint", "type": "timeseries",
+        "description": "Requests per second broken down by API endpoint. Shows which endpoints are busiest. The /health endpoint is typically the most frequent due to healthchecks.",
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-        "targets": [
-          {
-            "expr": "sum by (handler) (rate(http_requests_total{environment=~\"$environment\"}[5m]))",
-            "legendFormat": "{{handler}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "targets": [{ "expr": "sum by (handler) (rate(http_requests_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{handler}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 11,
-        "title": "Latency p50 / p95 / p99",
-        "type": "timeseries",
+        "id": 11, "title": "Latency p50 / p95 / p99", "type": "timeseries",
+        "description": "Response time percentiles across all endpoints. p50 = median, p95 = 95th percentile (most users), p99 = tail latency. Spikes indicate Bee node slowness or heavy payloads.",
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
         "targets": [
-          {
-            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p50"
-          },
-          {
-            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p95"
-          },
-          {
-            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p99"
-          }
+          { "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p50" },
+          { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p95" },
+          { "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p99" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "s",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 5
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 5 } } }
       },
       {
-        "id": 20,
-        "title": "Uploads & Downloads",
-        "type": "timeseries",
+        "id": 20, "title": "Uploads & Downloads", "type": "timeseries",
+        "description": "Rate of data upload and download operations. 'error' lines indicate failed Bee node calls, stamp validation failures, or file size rejections.",
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
         "targets": [
-          {
-            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "uploads (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "uploads (error)"
-          },
-          {
-            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "downloads (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "downloads (error)"
-          }
+          { "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "uploads (ok)" },
+          { "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "uploads (error)" },
+          { "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "downloads (ok)" },
+          { "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "downloads (error)" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 21,
-        "title": "Stamp Purchases & Pool Acquires",
-        "type": "timeseries",
+        "id": 21, "title": "Stamp Purchases & Pool Acquires", "type": "timeseries",
+        "description": "Rate of stamp purchases (POST /stamps/) and pool acquisitions (POST /pool/acquire). Pool acquires are instant (<5s) while direct purchases take >1 minute. Errors indicate insufficient funds or Bee node issues.",
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
         "targets": [
-          {
-            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "purchases (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "purchases (error)"
-          },
-          {
-            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "pool acquires (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "pool acquires (error)"
-          }
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "purchases (ok)" },
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "purchases (error)" },
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "pool acquires (ok)" },
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "pool acquires (error)" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 30,
-        "title": "BZZ Balance",
-        "type": "timeseries",
+        "id": 30, "title": "BZZ Balance", "type": "timeseries",
+        "description": "Bee node wallet BZZ balance (for purchasing stamps). RED <1 BZZ (critical), YELLOW <5 BZZ (warning), GREEN >5 BZZ. Drops when stamps are purchased.",
         "gridPos": { "h": 8, "w": 6, "x": 0, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_wallet_bzz_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_wallet_bzz_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 31,
-        "title": "xDAI Balance",
-        "type": "timeseries",
+        "id": 31, "title": "xDAI Balance", "type": "timeseries",
+        "description": "Bee node xDAI balance (gas for Gnosis chain transactions). RED <0.1 xDAI (critical), YELLOW <0.5 xDAI (warning). Needed for stamp purchases and chequebook operations.",
         "gridPos": { "h": 8, "w": 6, "x": 6, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_wallet_xdai_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 0.1, "color": "yellow" },
-                { "value": 0.5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_wallet_xdai_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 0.1, "color": "yellow" }, { "value": 0.5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 32,
-        "title": "Chequebook Balance",
-        "type": "timeseries",
+        "id": 32, "title": "Chequebook Balance", "type": "timeseries",
+        "description": "Chequebook available BZZ balance (for bandwidth payments to other Bee nodes). RED <1 BZZ, YELLOW <5 BZZ. Depletes as data is uploaded/downloaded from the Swarm network.",
         "gridPos": { "h": 8, "w": 6, "x": 12, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_chequebook_available_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_chequebook_available_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 33,
-        "title": "Base ETH Balance",
-        "type": "timeseries",
+        "id": 33, "title": "Base ETH Balance", "type": "timeseries",
+        "description": "Gateway wallet ETH on Base chain (gas for x402 USDC settlement). RED <0.001 ETH (~10 txs, critical), YELLOW <0.005 ETH (~50 txs). Only relevant when x402 payments are enabled.",
         "gridPos": { "h": 8, "w": 6, "x": 18, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_base_eth_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "decimals": 6,
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 0.001, "color": "yellow" },
-                { "value": 0.005, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_base_eth_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "decimals": 6, "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 0.001, "color": "yellow" }, { "value": 0.005, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 40,
-        "title": "Stamp Pool Available",
-        "type": "timeseries",
+        "id": 40, "title": "Stamp Pool Available", "type": "timeseries",
+        "description": "Number of pre-purchased stamps available in the pool by size (small/medium/large). When this hits 0, pool acquire requests return 409 and users must purchase stamps directly (~1 min wait).",
         "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamp_pool_available{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}} — {{size}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "bars",
-              "fillOpacity": 50
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamp_pool_available{environment=~\"$environment\"}", "legendFormat": "{{environment}} — {{size}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 50 }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "green" }] } } }
       },
       {
-        "id": 41,
-        "title": "Total Stamps on Bee Node",
-        "type": "timeseries",
+        "id": 41, "title": "Total Stamps on Bee Node", "type": "timeseries",
+        "description": "Total number of postage stamps on the connected Bee node. Includes pool stamps, user-purchased stamps, and any pre-existing stamps.",
         "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamps_total{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 15
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamps_total{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 15 } } }
       },
       {
-        "id": 42,
-        "title": "Min Stamp TTL",
-        "type": "timeseries",
+        "id": 42, "title": "Min Stamp TTL", "type": "timeseries",
+        "description": "Lowest time-to-live among all active stamps (in hours). RED <24h (expiring soon), YELLOW <72h. When stamps expire, data stored with them becomes unretrievable.",
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamp_min_ttl_seconds{environment=~\"$environment\"} / 3600",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "h",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 15
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 24, "color": "yellow" },
-                { "value": 72, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamp_min_ttl_seconds{environment=~\"$environment\"} / 3600", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "h", "custom": { "drawStyle": "line", "fillOpacity": 15 }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 24, "color": "yellow" }, { "value": 72, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 50,
-        "title": "x402 Payment Modes",
-        "type": "timeseries",
+        "id": 50, "title": "x402 Payment Modes", "type": "timeseries",
+        "description": "Rate of x402 payment requests by mode. 'paid' = USDC payment verified, 'free' = free tier access granted, 'rejected' = no payment provided (402 returned). Only active when X402_ENABLED=true.",
         "gridPos": { "h": 8, "w": 8, "x": 0, "y": 36 },
-        "targets": [
-          {
-            "expr": "sum(rate(gateway_x402_payments_total{environment=~\"$environment\"}[5m])) by (mode)",
-            "legendFormat": "{{mode}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 20
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(gateway_x402_payments_total{environment=~\"$environment\"}[5m])) by (mode)", "legendFormat": "{{mode}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 } } }
       },
       {
-        "id": 51,
-        "title": "Rate Limit Hits",
-        "type": "timeseries",
+        "id": 51, "title": "Rate Limit Hits", "type": "timeseries",
+        "description": "Rate of 429 Too Many Requests responses from the global rate limiter. High values indicate aggressive clients or insufficient rate limit configuration. Only active when X402_ENABLED=false (x402 has its own limiter).",
         "gridPos": { "h": 8, "w": 8, "x": 8, "y": 36 },
-        "targets": [
-          {
-            "expr": "rate(gateway_rate_limit_hits_total{environment=~\"$environment\"}[5m])",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20
-            },
-            "color": { "fixedColor": "orange", "mode": "fixed" }
-          }
-        }
+        "targets": [{ "expr": "rate(gateway_rate_limit_hits_total{environment=~\"$environment\"}[5m])", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20 }, "color": { "fixedColor": "orange", "mode": "fixed" } } }
       },
       {
-        "id": 52,
-        "title": "Bee API Errors",
-        "type": "timeseries",
+        "id": 52, "title": "Bee API Errors", "type": "timeseries",
+        "description": "Rate of failed HTTP requests to the upstream Bee node, by endpoint (batches, upload, download, purchase, wallet). Sustained errors indicate the Bee node is down or unreachable. Check /health for specific error messages.",
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 36 },
-        "targets": [
-          {
-            "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)",
-            "legendFormat": "{{endpoint}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 20
-            },
-            "color": { "fixedColor": "red", "mode": "fixed" }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 }, "color": { "fixedColor": "red", "mode": "fixed" } } }
       }
     ],
     "schemaVersion": 39


### PR DESCRIPTION
## Summary

- **Fix**: Stamp pool metrics poller was looking for wrong key in `get_status()` response — now correctly reads `current_levels` and `reserve_config`
- **Dashboard**: Added descriptions to all 17 panels explaining what each metric means, thresholds, and when to worry. Hover the (i) icon on any panel title to see.
- **Dashboard**: Added Bee API Errors panel
- **Docs**: Updated CLAUDE.md and README.md with full monitoring architecture, Grafana Cloud setup instructions, and local dev stack usage

Dashboard already pushed to Grafana Cloud (version 3).

## Why panels show "No data"

- **Stamp Pool**: Was broken (fixed in this PR). Will populate after next deploy.
- **x402 Payments**: Only appears after actual x402 requests are made (paid/free/rejected)
- **Uploads/Downloads**: Only appears after actual upload/download API calls
- **Stamp Purchases**: Only appears after stamp purchase requests
- **Rate Limit Hits**: Only when global rate limiter is active (disabled when x402 enabled)

These are counters — they only show data after their first increment. This is normal Prometheus behavior.