### PR TITLE
Merge dev to main: monitoring, Alloy, pool fix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,6 +108,12 @@ SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
 # Note: Pool will auto-purchase stamps when reserve is low.
 # Ensure Bee node wallet has sufficient xBZZ and xDAI.
 
+# === Monitoring/Metrics ===
+# Prometheus metrics endpoint at /metrics for operational monitoring.
+# METRICS_ENABLED=true                       # Expose /metrics endpoint (default: true)
+# METRICS_BALANCE_POLL_SECONDS=60            # How often to poll wallet balances for metrics (default: 60)
+# GATEWAY_ENVIRONMENT=development            # Environment label: development, staging, production
+
 # === Notary/Provenance Signing (Optional) ===
 # Gateway notary signing for document provenance.
 # See docs/notary-guide.md for full documentation.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,8 +102,13 @@ jobs:
           EOF
 
       - name: deploy
-        run: >
-          cd /opt/ && rm -rf swarm_connect && git clone -b $GITHUB_REF_NAME https://github.com/datafund/swarm_connect.git && cd swarm_connect && docker compose up -d
+        run: |
+          cd /opt/ && rm -rf swarm_connect && git clone -b $GITHUB_REF_NAME https://github.com/datafund/swarm_connect.git && cd swarm_connect
+          cat > .env << EOF
+          GRAFANA_CLOUD_PROM_USERNAME=${{ secrets.GRAFANA_CLOUD_PROM_USERNAME }}
+          GRAFANA_CLOUD_API_TOKEN=${{ secrets.GRAFANA_CLOUD_API_TOKEN }}
+          EOF
+          docker compose up -d --force-recreate
 
       - name: post-deploy diagnostics
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,7 @@ jobs:
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}
           METRICS_ENABLED=${{ vars.METRICS_ENABLED || 'true' }}
           METRICS_BALANCE_POLL_SECONDS=${{ vars.METRICS_BALANCE_POLL_SECONDS || '60' }}
-          GATEWAY_ENVIRONMENT=staging
+          GATEWAY_ENVIRONMENT=development
           EOF
 
       - name: write env file for main
@@ -98,7 +98,7 @@ jobs:
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}
           METRICS_ENABLED=${{ vars.METRICS_ENABLED || 'true' }}
           METRICS_BALANCE_POLL_SECONDS=${{ vars.METRICS_BALANCE_POLL_SECONDS || '60' }}
-          GATEWAY_ENVIRONMENT=production
+          GATEWAY_ENVIRONMENT=main
           EOF
 
       - name: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,9 @@ jobs:
           RATE_LIMIT_ENABLED=${{ vars.RATE_LIMIT_ENABLED || 'true' }}
           RATE_LIMIT_PER_MINUTE=${{ vars.RATE_LIMIT_PER_MINUTE || '60' }}
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}
+          METRICS_ENABLED=${{ vars.METRICS_ENABLED || 'true' }}
+          METRICS_BALANCE_POLL_SECONDS=${{ vars.METRICS_BALANCE_POLL_SECONDS || '60' }}
+          GATEWAY_ENVIRONMENT=staging
           EOF
 
       - name: write env file for main
@@ -93,6 +96,9 @@ jobs:
           RATE_LIMIT_ENABLED=${{ vars.RATE_LIMIT_ENABLED || 'true' }}
           RATE_LIMIT_PER_MINUTE=${{ vars.RATE_LIMIT_PER_MINUTE || '60' }}
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}
+          METRICS_ENABLED=${{ vars.METRICS_ENABLED || 'true' }}
+          METRICS_BALANCE_POLL_SECONDS=${{ vars.METRICS_BALANCE_POLL_SECONDS || '60' }}
+          GATEWAY_ENVIRONMENT=production
           EOF
 
       - name: deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,11 @@ Security settings:
 - `RATE_LIMIT_PER_MINUTE`: Requests per minute per IP (default: `60`)
 - `RATE_LIMIT_BURST`: Extra burst capacity above per-minute limit (default: `10`)
 
+Monitoring:
+- `METRICS_ENABLED`: Expose `/metrics` Prometheus endpoint (default: `true`)
+- `METRICS_BALANCE_POLL_SECONDS`: Wallet balance polling interval (default: `60`)
+- `GATEWAY_ENVIRONMENT`: Environment label for metrics (default: `development`)
+
 Notary signing (optional):
 - `NOTARY_ENABLED`: Enable notary signing feature (default: `false`)
 - `NOTARY_PRIVATE_KEY`: Hex-encoded Ethereum private key for signing (64 characters, no 0x prefix). Generate with `python scripts/generate_notary_key.py`
@@ -327,6 +332,62 @@ mcp__context7__get-library-docs with the resolved library ID
 
 **Note**: If ethersphere/bee is not available in Context7, implement functionality based on observed API behavior and document any assumptions clearly.
 
+## Monitoring
+
+### Prometheus Metrics
+
+The gateway exposes a `/metrics` endpoint (Prometheus text format) when `METRICS_ENABLED=true`.
+
+**Auto-instrumented** (from `prometheus-fastapi-instrumentator`):
+- `http_requests_total{method, handler, status}` — request count
+- `http_request_duration_seconds{method, handler}` — latency histogram
+- `http_requests_in_progress` — active requests gauge
+
+**Custom counters** (incremented in endpoint handlers):
+- `gateway_uploads_total{status}`, `gateway_upload_bytes_total`
+- `gateway_downloads_total{status}`
+- `gateway_stamp_purchases_total{size, status}`
+- `gateway_pool_acquires_total{size, status}`
+- `gateway_notary_signatures_total{status}`
+- `gateway_x402_payments_total{mode}` (paid/free/rejected)
+- `gateway_rate_limit_hits_total`
+
+**Custom gauges** (polled every `METRICS_BALANCE_POLL_SECONDS`):
+- `gateway_wallet_bzz_balance`, `gateway_wallet_xdai_balance`
+- `gateway_chequebook_available_balance`, `gateway_base_eth_balance`
+- `gateway_stamp_pool_available{size}`, `gateway_stamps_total`
+- `gateway_stamp_min_ttl_seconds`, `gateway_uptime_seconds`
+
+**Info**: `gateway_info{version, environment, x402_enabled, pool_enabled, notary_enabled}`
+
+### Local Monitoring Stack
+
+A local Prometheus + Grafana setup is in `monitoring/` for development:
+
+```bash
+# Start the gateway
+SWARM_BEE_API_URL=http://localhost:1633 python run.py
+
+# Start Prometheus + Grafana (in another terminal)
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+
+# Access:
+# - Gateway metrics: http://localhost:8000/metrics
+# - Prometheus:      http://localhost:9090
+# - Grafana:         http://localhost:3000 (admin/admin)
+
+# Stop
+docker compose -f monitoring/docker-compose.monitoring.yml down
+```
+
+### Monitoring Checklist for New Features
+
+When adding a new feature, consider:
+- **Does it need a counter?** New operation type (API call, transaction) → add a Counter in `app/services/metrics.py`
+- **Does it need a gauge?** New stateful resource (balance, pool, queue) → add a Gauge
+- **Does it need an alert?** New failure mode → document the alert rule
+- **Config?** → Update `.env.example` and `deploy.yml`
+
 ## Documentation Maintenance
 
 ### Architecture Documentation
@@ -494,3 +555,58 @@ If the remote gateway (provenance-gateway.datafund.io) returns 503 or appears br
 - Do NOT include Claude/AI mentions, co-author tags, or "Generated with Claude" footers in commit messages
 - Do NOT include "Generated with Claude Code" or similar footers in PR descriptions
 - Keep commit messages and PR descriptions clean and professional - just describe the changes
+
+## PLUR Domain Scoping
+
+When calling `plur_learn`, always set:
+- `domain`: `provenance.gateway`
+- `scope`: `project:swarm-connect`
+
+This ensures engrams are tagged for retrieval in the right context across the global store.
+
+## PLUR Memory
+
+You have persistent memory via PLUR. Corrections, preferences, and conventions persist across sessions as engrams.
+
+> **PLUR is its own MCP server.** The tools below come from the `plur` MCP server registered by `plur init` — `plur_session_start`, `plur_learn`, `plur_recall_hybrid`, `plur_feedback`, `plur_session_end`. If you do not see these exact tool names, **PLUR is not connected**: stop and run `plur doctor` to diagnose. Do **not** substitute tools from other MCP servers (e.g. `datacore_*`) — those belong to a different system and will not persist anything for PLUR.
+
+### Session Workflow
+
+1. **Start**: Call `plur_session_start` with task description — injects relevant engrams
+2. **Learn**: When corrected or discovering something new, call `plur_learn` immediately
+3. **Recall**: Before answering factual questions, call `plur_recall_hybrid` — check memory first
+4. **Feedback**: Rate injected engrams with `plur_feedback` (positive/negative) — trains relevance
+5. **End**: Call `plur_session_end` with summary + engram_suggestions
+
+Do not ask permission to use these tools — they are your memory system.
+
+### When to check memory
+
+Before reaching for web search, file reads, or guessing — apply this priority:
+1. Is the answer already in engrams? → `plur_recall_hybrid`
+2. Is the answer in the local filesystem? → Read/Grep/Glob
+3. Is the answer derivable from context already loaded? → Just answer
+4. Only if 1-3 fail → Use external tools
+
+| Domain | When to recall |
+|--------|----------------|
+| Decisions | Past design choices, architecture rationale |
+| Corrections | API quirks, bugs, wrong assumptions |
+| Preferences | Formatting, tone, workflow, tool choices |
+| Conventions | Tag formats, file routing, naming rules |
+| Infrastructure | Server IPs, SSH configs, deployment targets |
+
+### When corrected
+
+When the user corrects you ("no, use X not Y", "that's wrong"):
+1. Call `plur_learn` immediately — before continuing the task
+2. Call `plur_feedback` with negative signal on the wrong engram if one was injected
+3. Then continue with the corrected approach
+
+### Verification
+
+When recalling facts that will drive actions:
+1. State the recalled fact explicitly before acting on it
+2. Include the engram ID or search that produced it
+3. If no engram matches, say so and verify from the filesystem
+4. Never interpolate between two engrams to produce a "probably correct" composite

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,30 @@ The gateway exposes a `/metrics` endpoint (Prometheus text format) when `METRICS
 
 **Info**: `gateway_info{version, environment, x402_enabled, pool_enabled, notary_enabled}`
 
+### Production Monitoring Stack
+
+```
+Gateway containers ──/metrics──> Alloy ──remote write──> Grafana Cloud
+  (port 8000)                   (Docker)                 (dashboards + alerts)
+```
+
+**How it works:**
+- Grafana Alloy runs as a Docker container alongside the gateways (`docker-compose.yml`)
+- Alloy scrapes `/metrics` from both gateway containers every 15s via Docker network
+- Alloy pushes metrics to Grafana Cloud Prometheus (remote write)
+- Grafana Cloud stores metrics (14-day retention) and hosts dashboards
+- Environment labels: `development` (dev branch) and `main` (main branch)
+
+**Credentials** (stored in GitHub secrets, injected at deploy):
+- `GRAFANA_CLOUD_PROM_USERNAME` — Prometheus instance ID
+- `GRAFANA_CLOUD_API_TOKEN` — API token with `metrics:write` scope
+
+**Dashboard:** `datafund.grafana.net/d/gateway-overview`
+
+**Key files:**
+- `monitoring/alloy/config.alloy` — Alloy scrape + remote write config
+- `monitoring/provisioning/dashboards/gateway-overview.json` — dashboard JSON (pushed to Grafana Cloud via API)
+
 ### Local Monitoring Stack
 
 A local Prometheus + Grafana setup is in `monitoring/` for development:
@@ -375,6 +399,11 @@ docker compose -f monitoring/docker-compose.monitoring.yml up -d
 # - Gateway metrics: http://localhost:8000/metrics
 # - Prometheus:      http://localhost:9090
 # - Grafana:         http://localhost:3000 (admin/admin)
+
+# Push dashboard to local Grafana
+curl -X POST http://admin:admin@localhost:3000/api/dashboards/db \
+  -H "Content-Type: application/json" \
+  -d @monitoring/provisioning/dashboards/gateway-overview.json
 
 # Stop
 docker compose -f monitoring/docker-compose.monitoring.yml down

--- a/README.md
+++ b/README.md
@@ -380,6 +380,28 @@ X402_AUDIT_LOG_PATH=logs/x402_audit.jsonl
 
 See [x402 Operator Guide](docs/x402-operator-guide.md) for complete setup instructions.
 
+## Monitoring
+
+The gateway exposes a Prometheus metrics endpoint at `GET /metrics` for operational monitoring.
+
+**What's tracked:**
+- HTTP request rate, latency, and error rate (auto-instrumented)
+- Upload/download counts and bytes transferred
+- Stamp purchases and pool acquisitions
+- Wallet balances (BZZ, xDAI, chequebook, Base ETH)
+- Stamp pool availability and TTL
+- x402 payment mode breakdown
+- Rate limit rejections
+
+**Configuration:**
+```bash
+METRICS_ENABLED=true                # Expose /metrics (default: true)
+METRICS_BALANCE_POLL_SECONDS=60     # Balance polling interval (default: 60s)
+GATEWAY_ENVIRONMENT=production      # Environment label for multi-instance setups
+```
+
+**Stack:** Prometheus + Grafana Cloud + Telegram alerting. See the [monitoring epic](https://github.com/datafund/swarm_connect/issues/179) for setup details.
+
 ## API Endpoints
 
 ### Stamp Management Endpoints

--- a/README.md
+++ b/README.md
@@ -382,25 +382,51 @@ See [x402 Operator Guide](docs/x402-operator-guide.md) for complete setup instru
 
 ## Monitoring
 
-The gateway exposes a Prometheus metrics endpoint at `GET /metrics` for operational monitoring.
+The gateway has built-in Prometheus monitoring with a Grafana Cloud dashboard.
+
+**Architecture:**
+```
+Gateway ──/metrics──> Grafana Alloy ──remote write──> Grafana Cloud
+                      (Docker)                        (dashboards + alerts)
+```
+
+- Gateway exposes `GET /metrics` with Prometheus text format
+- [Grafana Alloy](https://grafana.com/docs/alloy/) runs as a sidecar container, scrapes metrics every 15s
+- Metrics are pushed to Grafana Cloud (free tier: 10k series, 14-day retention)
+- Dashboard: [datafund.grafana.net/d/gateway-overview](https://datafund.grafana.net/d/gateway-overview)
 
 **What's tracked:**
-- HTTP request rate, latency, and error rate (auto-instrumented)
+- HTTP request rate, latency percentiles (p50/p95/p99), and error rate
 - Upload/download counts and bytes transferred
 - Stamp purchases and pool acquisitions
-- Wallet balances (BZZ, xDAI, chequebook, Base ETH)
-- Stamp pool availability and TTL
-- x402 payment mode breakdown
+- Wallet balances (BZZ, xDAI, chequebook, Base ETH) with alert thresholds
+- Stamp pool availability by size and minimum TTL
+- x402 payment mode breakdown (paid/free/rejected)
+- Bee node API error rate by endpoint
 - Rate limit rejections
 
 **Configuration:**
 ```bash
 METRICS_ENABLED=true                # Expose /metrics (default: true)
 METRICS_BALANCE_POLL_SECONDS=60     # Balance polling interval (default: 60s)
-GATEWAY_ENVIRONMENT=production      # Environment label for multi-instance setups
+GATEWAY_ENVIRONMENT=development     # Environment label: development or main
 ```
 
-**Stack:** Prometheus + Grafana Cloud + Telegram alerting. See the [monitoring epic](https://github.com/datafund/swarm_connect/issues/179) for setup details.
+**Local development:**
+```bash
+# Run local Prometheus + Grafana
+docker compose -f monitoring/docker-compose.monitoring.yml up -d
+# Prometheus: http://localhost:9090
+# Grafana:    http://localhost:3000 (admin/admin)
+```
+
+**Grafana Cloud setup** (for new deployments):
+1. Create a [Grafana Cloud](https://grafana.com/products/cloud/) account (free tier)
+2. Create an access policy with `metrics:write` scope, generate a token
+3. Set GitHub secrets: `GRAFANA_CLOUD_PROM_USERNAME` (instance ID) and `GRAFANA_CLOUD_API_TOKEN`
+4. Alloy deploys automatically via `docker-compose.yml` on next push
+
+See the [monitoring epic](https://github.com/datafund/swarm_connect/issues/179) for full details.
 
 ## API Endpoints
 

--- a/app/api/endpoints/data.py
+++ b/app/api/endpoints/data.py
@@ -35,6 +35,9 @@ from app.services.provenance import (
     NotaryNotEnabledError
 )
 from app.services.signing import NotConfiguredError
+from app.services.metrics import (
+    uploads_total, upload_bytes_total, downloads_total, notary_signatures_total,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -307,7 +310,9 @@ async def upload_data(
                 data_bytes = signed_doc.raw_json.encode('utf-8')
                 content_type = "application/json"  # Signed documents are always JSON
                 logger.info(f"Document signed by notary, signatures count: {len(signed_doc.signatures)}")
+                notary_signatures_total.labels(status="success").inc()
             except NotaryNotEnabledError as e:
+                notary_signatures_total.labels(status="error").inc()
                 raise HTTPException(
                     status_code=400,
                     detail={
@@ -317,6 +322,7 @@ async def upload_data(
                     }
                 )
             except NotConfiguredError as e:
+                notary_signatures_total.labels(status="error").inc()
                 raise HTTPException(
                     status_code=400,
                     detail={
@@ -326,6 +332,7 @@ async def upload_data(
                     }
                 )
             except DocumentValidationError as e:
+                notary_signatures_total.labels(status="error").inc()
                 raise HTTPException(
                     status_code=400,
                     detail={
@@ -367,6 +374,9 @@ async def upload_data(
                 total_ms=total_ms
             )
 
+        uploads_total.labels(status="success").inc()
+        upload_bytes_total.inc(len(data_bytes))
+
         response = DataUploadResponse(
             reference=reference,
             message=f"File '{file.filename}' uploaded successfully",
@@ -389,8 +399,10 @@ async def upload_data(
         )
 
     except HTTPException:
+        uploads_total.labels(status="error").inc()
         raise  # Re-raise HTTP exceptions as-is
     except httpx.HTTPError as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Swarm API error during upload: {e}")
         # Check if the failure was due to stamp issues
         failure_info = await check_upload_failure_reason(stamp_id, str(e))
@@ -406,9 +418,11 @@ async def upload_data(
             raise HTTPException(status_code=400, detail=detail)
         raise HTTPException(status_code=502, detail="Failed to upload data to Swarm. The Bee node may be unavailable.")
     except ValueError as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Data processing error during upload: {e}")
         raise HTTPException(status_code=400, detail="Data upload error. Please check your request and try again.")
     except Exception as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Unexpected error during upload: {e}")
         raise HTTPException(status_code=500, detail="Internal server error during upload")
 
@@ -437,6 +451,8 @@ async def download_data(
         # Detect content type and generate user-friendly filename
         content_type, filename = _detect_content_type_and_filename(data_bytes, reference)
 
+        downloads_total.labels(status="success").inc()
+
         # Return raw data with user-friendly filename
         return Response(
             content=data_bytes,
@@ -449,12 +465,15 @@ async def download_data(
         )
 
     except FileNotFoundError as e:
+        downloads_total.labels(status="error").inc()
         logger.warning(f"Data not found for reference {reference}: {e}")
         raise HTTPException(status_code=404, detail=f"Data not found for reference {reference}")
     except httpx.HTTPError as e:
+        downloads_total.labels(status="error").inc()
         logger.error(f"Swarm API error during download: {e}")
         raise HTTPException(status_code=502, detail="Failed to download data from Swarm. The Bee node may be unavailable.")
     except Exception as e:
+        downloads_total.labels(status="error").inc()
         logger.error(f"Unexpected error during download: {e}")
         raise HTTPException(status_code=500, detail="Internal server error during download")
 
@@ -496,6 +515,8 @@ async def download_data_json(
         # Encode as base64
         data_b64 = base64.b64encode(data_bytes).decode('utf-8')
 
+        downloads_total.labels(status="success").inc()
+
         return DataDownloadResponse(
             data=data_b64,
             content_type=content_type,
@@ -504,12 +525,15 @@ async def download_data_json(
         )
 
     except FileNotFoundError as e:
+        downloads_total.labels(status="error").inc()
         logger.warning(f"Data not found for reference {reference}: {e}")
         raise HTTPException(status_code=404, detail=f"Data not found for reference {reference}")
     except httpx.HTTPError as e:
+        downloads_total.labels(status="error").inc()
         logger.error(f"Swarm API error during download: {e}")
         raise HTTPException(status_code=502, detail="Failed to download data from Swarm. The Bee node may be unavailable.")
     except Exception as e:
+        downloads_total.labels(status="error").inc()
         logger.error(f"Unexpected error during download: {e}")
         raise HTTPException(status_code=500, detail="Internal server error during download")
 
@@ -749,6 +773,9 @@ async def upload_manifest(
                 files_per_second=files_per_second
             )
 
+        uploads_total.labels(status="success").inc()
+        upload_bytes_total.inc(len(tar_bytes))
+
         response = ManifestUploadResponse(
             reference=reference,
             file_count=file_count,
@@ -776,14 +803,13 @@ async def upload_manifest(
         )
 
     except HTTPException:
-        # Re-raise HTTP exceptions as-is
+        uploads_total.labels(status="error").inc()
         raise
     except httpx.HTTPError as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Swarm API error during manifest upload: {e}")
-        # Check if the failure was due to stamp issues
         failure_info = await check_upload_failure_reason(stamp_id, str(e))
         if failure_info:
-            # Return structured error response
             detail = {
                 "code": failure_info.get("code"),
                 "message": failure_info.get("message"),
@@ -794,8 +820,10 @@ async def upload_manifest(
             raise HTTPException(status_code=400, detail=detail)
         raise HTTPException(status_code=502, detail="Failed to upload collection to Swarm. The Bee node may be unavailable.")
     except ValueError as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Data processing error during manifest upload: {e}")
         raise HTTPException(status_code=400, detail="Manifest upload error. Please check your request and try again.")
     except Exception as e:
+        uploads_total.labels(status="error").inc()
         logger.error(f"Unexpected error during manifest upload: {e}")
         raise HTTPException(status_code=500, detail="Internal server error during manifest upload")

--- a/app/api/endpoints/pool.py
+++ b/app/api/endpoints/pool.py
@@ -16,6 +16,7 @@ import logging
 from app.core.config import settings
 from app.services.stamp_pool import stamp_pool_manager, PoolStampStatus
 from app.services.stamp_ownership import stamp_ownership_manager
+from app.services.metrics import pool_acquires_total
 from app.api.models.stamp import SIZE_PRESETS
 
 router = APIRouter()
@@ -206,6 +207,7 @@ async def acquire_stamp(
 
     if not stamp:
         size_name = depth_to_size_name(requested_depth)
+        pool_acquires_total.labels(size=size_name, status="error").inc()
         raise HTTPException(
             status_code=409,
             detail={
@@ -221,7 +223,8 @@ async def acquire_stamp(
     released = stamp_pool_manager.release_stamp(stamp.batch_id, released_to=client_ip)
 
     if not released:
-        # Race condition - stamp was taken between check and release
+        size_name = depth_to_size_name(requested_depth)
+        pool_acquires_total.labels(size=size_name, status="error").inc()
         raise HTTPException(
             status_code=409,
             detail={
@@ -255,6 +258,7 @@ async def acquire_stamp(
         logger.info(f"Triggered immediate replenishment for depth {released.depth}")
 
     size_name = depth_to_size_name(released.depth)
+    pool_acquires_total.labels(size=size_name, status="success").inc()
 
     message = f"Stamp acquired from pool (depth={released.depth}, size={size_name})"
     if fallback_used:

--- a/app/api/endpoints/stamps.py
+++ b/app/api/endpoints/stamps.py
@@ -9,6 +9,7 @@ from app.core.config import settings
 from app.services import swarm_api
 from app.services.stamp_ownership import stamp_ownership_manager
 from app.services.stamp_tracker import record_purchase
+from app.services.metrics import stamp_purchases_total
 from app.api.models.stamp import (
     StampDetails,
     StampPurchaseRequest,
@@ -409,26 +410,34 @@ async def purchase_stamp(
                 source="direct_purchase"
             )
 
+        size_label = stamp_request.size or "custom"
+        stamp_purchases_total.labels(size=size_label, status="success").inc()
+
         return StampPurchaseResponse(
             batchID=batch_id,
             message="Postage stamp purchased successfully"
         )
 
     except HTTPException:
+        size_label = stamp_request.size or "custom"
+        stamp_purchases_total.labels(size=size_label, status="error").inc()
         raise  # Re-raise HTTP exceptions as-is
     except httpx.HTTPError as e:
+        stamp_purchases_total.labels(size=stamp_request.size or "custom", status="error").inc()
         logger.error(f"Failed to purchase stamp from Swarm API: {e}")
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
             detail="Could not purchase stamp. The Bee node may be unavailable."
         )
     except ValueError as e:
+        stamp_purchases_total.labels(size=stamp_request.size or "custom", status="error").inc()
         logger.error(f"Invalid response from Swarm API during stamp purchase: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Invalid response from Swarm API. Please try again."
         )
     except Exception as e:
+        stamp_purchases_total.labels(size=stamp_request.size or "custom", status="error").inc()
         logger.error(f"Unexpected error during stamp purchase: {e}", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -107,6 +107,11 @@ class Settings(BaseSettings):
     RATE_LIMIT_PER_MINUTE: int = 60  # Requests per minute per IP
     RATE_LIMIT_BURST: int = 10  # Extra burst capacity above per-minute limit
 
+    # === Metrics/Monitoring ===
+    METRICS_ENABLED: bool = True  # Expose /metrics endpoint for Prometheus
+    METRICS_BALANCE_POLL_SECONDS: int = 60  # How often to poll wallet balances for metrics
+    GATEWAY_ENVIRONMENT: str = "development"  # Environment label (development/staging/production)
+
     # === CORS Settings ===
     # Enable CORS for browser-based SDK usage (e.g., React/Vite frontends)
     CORS_ALLOWED_ORIGINS: str = "*"  # Comma-separated origins or "*" for all

--- a/app/main.py
+++ b/app/main.py
@@ -27,9 +27,29 @@ async def lifespan(app: FastAPI):
         logger.info("Starting stamp pool background task")
         await stamp_pool_manager.start_background_task()
 
+    # Start metrics background polling if enabled
+    if settings.METRICS_ENABLED:
+        from app.services.metrics import (
+            start_metrics_background_task,
+            gateway_info,
+        )
+        gateway_info.info({
+            "version": VERSION,
+            "environment": settings.GATEWAY_ENVIRONMENT,
+            "x402_enabled": str(settings.X402_ENABLED),
+            "pool_enabled": str(settings.STAMP_POOL_ENABLED),
+            "notary_enabled": str(settings.NOTARY_ENABLED),
+        })
+        await start_metrics_background_task()
+
     yield
 
     # === Shutdown ===
+    # Stop metrics background task
+    if settings.METRICS_ENABLED:
+        from app.services.metrics import stop_metrics_background_task
+        await stop_metrics_background_task()
+
     # Stop stamp pool background task if running
     if settings.STAMP_POOL_ENABLED:
         from app.services.stamp_pool import stamp_pool_manager
@@ -76,6 +96,17 @@ app.add_middleware(
     allow_headers=["*"],
 )
 logger.info(f"CORS enabled for origins: {cors_origins}")
+
+# Add Prometheus metrics endpoint if enabled
+if settings.METRICS_ENABLED:
+    from prometheus_fastapi_instrumentator import Instrumentator
+    instrumentator = Instrumentator(
+        should_group_status_codes=False,
+        should_ignore_untemplated=True,
+        excluded_handlers=["/metrics"],
+    )
+    instrumentator.instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
+    logger.info("Prometheus metrics enabled at /metrics")
 
 # Build x402 dependency list for protected routers (stamps, data)
 if settings.X402_ENABLED:

--- a/app/middleware/rate_limit.py
+++ b/app/middleware/rate_limit.py
@@ -15,11 +15,12 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
 
 from app.core.config import settings
+from app.services.metrics import rate_limit_hits_total
 
 logger = logging.getLogger(__name__)
 
 # Paths exempt from rate limiting
-EXEMPT_PATHS = {"/", "/health", "/docs", "/redoc", "/openapi.json"}
+EXEMPT_PATHS = {"/", "/health", "/docs", "/redoc", "/openapi.json", "/metrics"}
 
 
 def _is_exempt_path(path: str) -> bool:
@@ -147,6 +148,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         allowed, stats = self._counter.is_allowed(client_ip, limit)
 
         if not allowed:
+            rate_limit_hits_total.inc()
             retry_after = stats.get("retry_after", 60)
             logger.warning(f"Rate limit exceeded for {client_ip}: {request.method} {request.url.path}")
             return JSONResponse(

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -1,0 +1,187 @@
+# app/services/metrics.py
+"""
+Prometheus metrics for the Provenance Gateway.
+
+Defines custom business metrics (gauges, counters, info) and a background
+task that periodically polls wallet balances and stamp pool state.
+"""
+import asyncio
+import logging
+import time
+
+from prometheus_client import Counter, Gauge, Info
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ── Info metric ──────────────────────────────────────────────────────────────
+
+gateway_info = Info("gateway", "Gateway version and configuration")
+
+# ── Gauges (updated by background poller) ────────────────────────────────────
+
+wallet_bzz_balance = Gauge(
+    "gateway_wallet_bzz_balance", "Bee node BZZ balance"
+)
+wallet_xdai_balance = Gauge(
+    "gateway_wallet_xdai_balance", "Bee node xDAI balance"
+)
+chequebook_available_balance = Gauge(
+    "gateway_chequebook_available_balance", "Chequebook available BZZ balance"
+)
+base_eth_balance = Gauge(
+    "gateway_base_eth_balance", "Base chain ETH balance for x402 gas"
+)
+stamp_pool_available = Gauge(
+    "gateway_stamp_pool_available", "Available stamps in pool by size", ["size"]
+)
+stamp_pool_target = Gauge(
+    "gateway_stamp_pool_target", "Target reserve by size", ["size"]
+)
+stamps_total = Gauge(
+    "gateway_stamps_total", "Total stamps on Bee node"
+)
+stamp_min_ttl_seconds = Gauge(
+    "gateway_stamp_min_ttl_seconds", "Lowest TTL among active stamps"
+)
+uptime_seconds = Gauge(
+    "gateway_uptime_seconds", "Process uptime in seconds"
+)
+
+# ── Application counters (incremented in endpoint handlers) ──────────────────
+
+uploads_total = Counter(
+    "gateway_uploads_total", "Total upload attempts", ["status"]
+)
+upload_bytes_total = Counter(
+    "gateway_upload_bytes_total", "Total bytes uploaded"
+)
+downloads_total = Counter(
+    "gateway_downloads_total", "Total download attempts", ["status"]
+)
+stamp_purchases_total = Counter(
+    "gateway_stamp_purchases_total", "Stamp purchases", ["size", "status"]
+)
+pool_acquires_total = Counter(
+    "gateway_pool_acquires_total", "Pool stamp acquisitions", ["size", "status"]
+)
+notary_signatures_total = Counter(
+    "gateway_notary_signatures_total", "Notary signing operations", ["status"]
+)
+x402_payments_total = Counter(
+    "gateway_x402_payments_total", "x402 payment mode breakdown", ["mode"]
+)
+rate_limit_hits_total = Counter(
+    "gateway_rate_limit_hits_total", "Rate limit rejections"
+)
+bee_api_errors_total = Counter(
+    "gateway_bee_api_errors_total", "Upstream Bee node errors", ["endpoint"]
+)
+
+# ── Background task ──────────────────────────────────────────────────────────
+
+_background_task = None
+_start_time = None
+
+
+async def _poll_balances():
+    """Periodically poll wallet balances and update Prometheus gauges."""
+    while True:
+        try:
+            # Update uptime
+            if _start_time is not None:
+                uptime_seconds.set(time.monotonic() - _start_time)
+
+            # Wallet balances (requires HTTP client to be initialized)
+            try:
+                from app.services.swarm_api import get_wallet_info
+                wallet = await get_wallet_info()
+                bzz_raw = wallet.get("bzzBalance", "0")
+                # BZZ balance is in PLUR (1 BZZ = 1e16 PLUR)
+                bzz = int(bzz_raw) / 1e16 if bzz_raw else 0
+                wallet_bzz_balance.set(bzz)
+            except Exception as e:
+                logger.debug(f"Metrics: failed to get wallet info: {e}")
+
+            # Chequebook balance
+            try:
+                from app.services.swarm_api import get_chequebook_info
+                cheque = await get_chequebook_info()
+                available_raw = cheque.get("availableBalance", "0")
+                available = int(available_raw) / 1e16 if available_raw else 0
+                chequebook_available_balance.set(available)
+            except Exception as e:
+                logger.debug(f"Metrics: failed to get chequebook info: {e}")
+
+            # Base ETH balance (only when x402 enabled)
+            if settings.X402_ENABLED:
+                try:
+                    from app.x402.base_balance import check_base_eth_balance
+                    base = await check_base_eth_balance()
+                    base_eth_balance.set(base.get("balance_eth", 0))
+                except Exception as e:
+                    logger.debug(f"Metrics: failed to get base ETH balance: {e}")
+
+            # Stamp counts and min TTL
+            try:
+                from app.services.swarm_api import get_all_stamps
+                all_stamps = await get_all_stamps()
+                stamps_total.set(len(all_stamps))
+
+                # Find minimum TTL
+                min_ttl = float("inf")
+                for s in all_stamps:
+                    ttl = s.get("batchTTL", 0)
+                    if isinstance(ttl, (int, float)) and ttl > 0:
+                        min_ttl = min(min_ttl, ttl)
+                if min_ttl < float("inf"):
+                    stamp_min_ttl_seconds.set(min_ttl)
+                else:
+                    stamp_min_ttl_seconds.set(0)
+            except Exception as e:
+                logger.debug(f"Metrics: failed to get stamp info: {e}")
+
+            # Stamp pool state
+            if settings.STAMP_POOL_ENABLED:
+                try:
+                    from app.services.stamp_pool import stamp_pool_manager
+                    status = stamp_pool_manager.get_status()
+                    reserves = status.get("reserves", {})
+                    for size_name, info in reserves.items():
+                        stamp_pool_available.labels(size=size_name).set(
+                            info.get("available", 0)
+                        )
+                        stamp_pool_target.labels(size=size_name).set(
+                            info.get("target", 0)
+                        )
+                except Exception as e:
+                    logger.debug(f"Metrics: failed to get pool status: {e}")
+
+        except Exception as e:
+            logger.warning(f"Metrics background poll error: {e}")
+
+        await asyncio.sleep(settings.METRICS_BALANCE_POLL_SECONDS)
+
+
+async def start_metrics_background_task():
+    """Start the background balance polling task."""
+    global _background_task, _start_time
+    _start_time = time.monotonic()
+    _background_task = asyncio.create_task(_poll_balances())
+    logger.info(
+        f"Metrics background task started (poll interval: {settings.METRICS_BALANCE_POLL_SECONDS}s)"
+    )
+
+
+async def stop_metrics_background_task():
+    """Stop the background balance polling task."""
+    global _background_task
+    if _background_task is not None:
+        _background_task.cancel()
+        try:
+            await _background_task
+        except asyncio.CancelledError:
+            pass
+        _background_task = None
+        logger.info("Metrics background task stopped")

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -148,12 +148,10 @@ async def _poll_balances():
                     from app.services.stamp_pool import stamp_pool_manager
                     DEPTH_TO_SIZE = {17: "small", 20: "medium", 22: "large"}
                     status = stamp_pool_manager.get_status()
-                    current_levels = status.get("current_levels", {})
-                    reserve_config = status.get("reserve_config", {})
-                    for depth, target in reserve_config.items():
+                    for depth, target in status.reserve_config.items():
                         size_name = DEPTH_TO_SIZE.get(int(depth), f"depth-{depth}")
                         stamp_pool_available.labels(size=size_name).set(
-                            current_levels.get(int(depth), 0)
+                            status.current_levels.get(int(depth), 0)
                         )
                         stamp_pool_target.labels(size=size_name).set(target)
                 except Exception as e:

--- a/app/services/metrics.py
+++ b/app/services/metrics.py
@@ -146,15 +146,16 @@ async def _poll_balances():
             if settings.STAMP_POOL_ENABLED:
                 try:
                     from app.services.stamp_pool import stamp_pool_manager
+                    DEPTH_TO_SIZE = {17: "small", 20: "medium", 22: "large"}
                     status = stamp_pool_manager.get_status()
-                    reserves = status.get("reserves", {})
-                    for size_name, info in reserves.items():
+                    current_levels = status.get("current_levels", {})
+                    reserve_config = status.get("reserve_config", {})
+                    for depth, target in reserve_config.items():
+                        size_name = DEPTH_TO_SIZE.get(int(depth), f"depth-{depth}")
                         stamp_pool_available.labels(size=size_name).set(
-                            info.get("available", 0)
+                            current_levels.get(int(depth), 0)
                         )
-                        stamp_pool_target.labels(size=size_name).set(
-                            info.get("target", 0)
-                        )
+                        stamp_pool_target.labels(size=size_name).set(target)
                 except Exception as e:
                     logger.debug(f"Metrics: failed to get pool status: {e}")
 

--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -476,8 +476,11 @@ class StampPoolManager:
                 needed = target_count - current_count
                 if needed > 0:
                     logger.info(f"Pool depth {depth}: need {needed} stamps (have {current_count}, target {target_count})")
-                    for _ in range(needed):
+                    for i in range(needed):
                         try:
+                            # Delay between purchases to avoid Bee node rate limiting (429)
+                            if i > 0:
+                                await asyncio.sleep(15)
                             batch_id = await self._purchase_stamp(depth)
                             if batch_id:
                                 results["stamps_purchased"] += 1
@@ -516,8 +519,8 @@ class StampPoolManager:
 
         return results
 
-    async def _purchase_stamp(self, depth: int) -> Optional[str]:
-        """Purchase a new stamp for the pool."""
+    async def _purchase_stamp(self, depth: int, max_retries: int = 3) -> Optional[str]:
+        """Purchase a new stamp for the pool. Retries on 429 rate limiting."""
         try:
             # Get current price (Bee API returns currentPrice as a string)
             chainstate = await swarm_api.get_chainstate()
@@ -533,8 +536,22 @@ class StampPoolManager:
 
             logger.info(f"Purchasing stamp for pool: depth={depth}, amount={amount}, duration={duration_hours}h")
 
-            # Purchase the stamp
-            batch_id = await swarm_api.purchase_postage_stamp(amount, depth, label)
+            # Purchase the stamp with retry on 429
+            batch_id = None
+            for attempt in range(max_retries):
+                try:
+                    batch_id = await swarm_api.purchase_postage_stamp(amount, depth, label)
+                    break
+                except Exception as e:
+                    if "429" in str(e) and attempt < max_retries - 1:
+                        wait_time = 15 * (attempt + 1)
+                        logger.warning(f"Bee node rate limited (429), retrying in {wait_time}s (attempt {attempt + 1}/{max_retries})")
+                        await asyncio.sleep(wait_time)
+                    else:
+                        raise
+
+            if not batch_id:
+                return None
 
             # Wait for stamp to become usable (up to 90 seconds)
             usable = await self._wait_for_stamp_usable(batch_id, timeout=90)

--- a/app/services/swarm_api.py
+++ b/app/services/swarm_api.py
@@ -9,8 +9,17 @@ from urllib.parse import urljoin
 from app.core.config import settings
 from app.services.http_client import get_client
 from app.services.stamp_ownership import stamp_ownership_manager
+from app.services.metrics import bee_api_errors_total
 
 logger = logging.getLogger(__name__)
+
+
+def _record_bee_error(endpoint: str):
+    """Increment Bee API error counter for the given endpoint."""
+    try:
+        bee_api_errors_total.labels(endpoint=endpoint).inc()
+    except Exception:
+        pass  # Never let metrics break the request
 
 async def get_all_stamps() -> List[Dict[str, Any]]:
     """
@@ -47,6 +56,7 @@ async def get_all_stamps() -> List[Dict[str, Any]]:
 
 
     except httpx.HTTPError as e:
+        _record_bee_error("batches")
         logger.error(f"Error fetching stamps from Swarm API ({api_url}): {e}")
         raise
 
@@ -147,6 +157,7 @@ async def purchase_postage_stamp(amount: int, depth: int, label: Optional[str] =
         return batch_id
 
     except httpx.HTTPError as e:
+        _record_bee_error("purchase")
         logger.error(f"Error purchasing stamp from Swarm API ({api_url}): {e}")
         raise
     except (ValueError, KeyError) as e:
@@ -637,6 +648,7 @@ async def upload_data_to_swarm(
         return reference
 
     except httpx.HTTPError as e:
+        _record_bee_error("upload")
         logger.error(f"Error uploading data to Swarm API ({api_url}): {e}")
         raise
     except (ValueError, KeyError) as e:
@@ -673,6 +685,7 @@ async def download_data_from_swarm(reference: str) -> bytes:
         return response.content
 
     except httpx.HTTPError as e:
+        _record_bee_error("download")
         logger.error(f"Error downloading data from Swarm API ({api_url}): {e}")
         raise
 
@@ -705,6 +718,7 @@ async def get_wallet_info() -> Dict[str, Any]:
         return response_json
 
     except httpx.HTTPError as e:
+        _record_bee_error("wallet")
         logger.error(f"Error fetching wallet info from Swarm API ({api_url}): {e}")
         raise
     except (ValueError, KeyError) as e:

--- a/app/x402/dependency.py
+++ b/app/x402/dependency.py
@@ -19,6 +19,7 @@ from x402.types import PaymentPayload
 from x402.facilitator import FacilitatorClient, FacilitatorConfig
 
 from app.core.config import settings
+from app.services.metrics import x402_payments_total
 from app.x402.pricing import get_price_quote
 from app.x402.ratelimit import check_rate_limit, get_rate_limit_headers, get_free_tier_stats
 from app.x402.base_balance import check_base_eth_balance
@@ -158,6 +159,7 @@ async def require_x402_payment(request: Request) -> None:
         free_tier_info = get_free_tier_stats(client_ip) if settings.X402_FREE_TIER_ENABLED else None
 
         logger.info(f"x402: No payment header, returning 402 for ${price_usd}")
+        x402_payments_total.labels(mode="rejected").inc()
 
         response_body = {
             "x402Version": X402_VERSION,
@@ -185,6 +187,7 @@ async def require_x402_payment(request: Request) -> None:
 
         if is_allowed:
             logger.info(f"x402: Free tier access granted for {client_ip} ({stats['requests_made']}/{stats['limit']} requests)")
+            x402_payments_total.labels(mode="free").inc()
             request.state.x402_mode = "free-tier"
             request.state.x402_payer = None
             request.state.x402_rate_limit_stats = stats
@@ -248,6 +251,7 @@ async def require_x402_payment(request: Request) -> None:
         raise HTTPException(status_code=402, detail=response_body)
 
     logger.info(f"x402: Payment verified for payer {verify_response.payer}")
+    x402_payments_total.labels(mode="paid").inc()
 
     # Store payment info on request.state for middleware settlement
     request.state.x402_mode = "paid"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,3 +35,15 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
+
+  alloy:
+    image: grafana/alloy:latest
+    volumes:
+      - ./monitoring/alloy/config.alloy:/etc/alloy/config.alloy:ro
+    environment:
+      - GRAFANA_CLOUD_PROM_USERNAME=${GRAFANA_CLOUD_PROM_USERNAME}
+      - GRAFANA_CLOUD_API_TOKEN=${GRAFANA_CLOUD_API_TOKEN}
+    command: ["run", "/etc/alloy/config.alloy"]
+    restart: unless-stopped
+    depends_on:
+      - provenance_gateway_dev

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,0 +1,51 @@
+// Grafana Alloy configuration for Provenance Gateway monitoring
+// Scrapes /metrics from gateway containers and pushes to Grafana Cloud
+
+// ── Scrape staging gateway ──────────────────────────────────────────────────
+
+prometheus.scrape "staging" {
+  targets = [{"__address__" = "provenance_gateway_dev:8000"}]
+  metrics_path = "/metrics"
+  scrape_interval = "15s"
+  forward_to = [prometheus.relabel.add_environment_staging.receiver]
+}
+
+prometheus.relabel "add_environment_staging" {
+  rule {
+    action       = "replace"
+    target_label = "environment"
+    replacement  = "staging"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Scrape production gateway ───────────────────────────────────────────────
+
+prometheus.scrape "production" {
+  targets = [{"__address__" = "provenance_gateway:8000"}]
+  metrics_path = "/metrics"
+  scrape_interval = "15s"
+  forward_to = [prometheus.relabel.add_environment_production.receiver]
+}
+
+prometheus.relabel "add_environment_production" {
+  rule {
+    action       = "replace"
+    target_label = "environment"
+    replacement  = "production"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud.receiver]
+}
+
+// ── Push to Grafana Cloud ───────────────────────────────────────────────────
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/push"
+
+    basic_auth {
+      username = env("GRAFANA_CLOUD_PROM_USERNAME")
+      password = env("GRAFANA_CLOUD_API_TOKEN")
+    }
+  }
+}

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -1,38 +1,38 @@
 // Grafana Alloy configuration for Provenance Gateway monitoring
 // Scrapes /metrics from gateway containers and pushes to Grafana Cloud
 
-// ── Scrape staging gateway ──────────────────────────────────────────────────
+// ── Scrape development gateway (dev branch) ─────────────────────────────────
 
-prometheus.scrape "staging" {
+prometheus.scrape "development" {
   targets = [{"__address__" = "provenance_gateway_dev:8000"}]
   metrics_path = "/metrics"
   scrape_interval = "15s"
-  forward_to = [prometheus.relabel.add_environment_staging.receiver]
+  forward_to = [prometheus.relabel.add_environment_development.receiver]
 }
 
-prometheus.relabel "add_environment_staging" {
+prometheus.relabel "add_environment_development" {
   rule {
     action       = "replace"
     target_label = "environment"
-    replacement  = "staging"
+    replacement  = "development"
   }
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }
 
-// ── Scrape production gateway ───────────────────────────────────────────────
+// ── Scrape main gateway (main branch) ───────────────────────────────────────
 
-prometheus.scrape "production" {
+prometheus.scrape "main" {
   targets = [{"__address__" = "provenance_gateway:8000"}]
   metrics_path = "/metrics"
   scrape_interval = "15s"
-  forward_to = [prometheus.relabel.add_environment_production.receiver]
+  forward_to = [prometheus.relabel.add_environment_main.receiver]
 }
 
-prometheus.relabel "add_environment_production" {
+prometheus.relabel "add_environment_main" {
   rule {
     action       = "replace"
     target_label = "environment"
-    replacement  = "production"
+    replacement  = "main"
   }
   forward_to = [prometheus.remote_write.grafana_cloud.receiver]
 }

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,38 @@
+---
+# Local monitoring stack for development
+# Usage: docker compose -f monitoring/docker-compose.monitoring.yml up -d
+#
+# Prometheus: http://localhost:9090
+# Grafana:    http://localhost:3000 (admin/admin)
+#
+# Expects the gateway running on host at localhost:8000 (python run.py)
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Viewer
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./provisioning:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  grafana-data:

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: "provenance-gateway"
+    metrics_path: "/metrics"
+    static_configs:
+      # host.docker.internal resolves to the host machine from inside Docker
+      - targets: ["host.docker.internal:8000"]
+        labels:
+          environment: "development"

--- a/monitoring/provisioning/dashboards/gateway-overview.json
+++ b/monitoring/provisioning/dashboards/gateway-overview.json
@@ -1,0 +1,530 @@
+{
+  "dashboard": {
+    "id": null,
+    "uid": "gateway-overview",
+    "title": "Provenance Gateway Overview",
+    "tags": ["gateway", "provenance"],
+    "timezone": "browser",
+    "refresh": "15s",
+    "time": {
+      "from": "now-1h",
+      "to": "now"
+    },
+    "panels": [
+      {
+        "id": 1,
+        "title": "Gateway Status",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+        "targets": [
+          {
+            "expr": "up{job=\"provenance-gateway\"}",
+            "legendFormat": "{{environment}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+            ],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "green" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 2,
+        "title": "Uptime",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
+        "targets": [
+          {
+            "expr": "gateway_uptime_seconds / 3600",
+            "legendFormat": "hours"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "h",
+            "decimals": 1,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "green" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 3,
+        "title": "Request Rate",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total[5m]))",
+            "legendFormat": "req/s"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "decimals": 2,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "blue" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 4,
+        "title": "Error Rate",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
+        "targets": [
+          {
+            "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) * 100 or vector(0)",
+            "legendFormat": "5xx %"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "percent",
+            "decimals": 1,
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "green" },
+                { "value": 1, "color": "yellow" },
+                { "value": 5, "color": "red" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 5,
+        "title": "Total Uploads",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
+        "targets": [
+          {
+            "expr": "gateway_uploads_total{status=\"success\"} or vector(0)",
+            "legendFormat": "uploads"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "purple" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 6,
+        "title": "Total Downloads",
+        "type": "stat",
+        "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
+        "targets": [
+          {
+            "expr": "gateway_downloads_total{status=\"success\"} or vector(0)",
+            "legendFormat": "downloads"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "blue" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 10,
+        "title": "Request Rate by Endpoint",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+        "targets": [
+          {
+            "expr": "sum by (handler) (rate(http_requests_total[5m]))",
+            "legendFormat": "{{handler}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 10
+            }
+          }
+        }
+      },
+      {
+        "id": 11,
+        "title": "Latency p50 / p95 / p99",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+        "targets": [
+          {
+            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p50"
+          },
+          {
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p95"
+          },
+          {
+            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "legendFormat": "p99"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "s",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 5
+            }
+          }
+        }
+      },
+      {
+        "id": 20,
+        "title": "Uploads & Downloads",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+        "targets": [
+          {
+            "expr": "sum(rate(gateway_uploads_total{status=\"success\"}[5m]))",
+            "legendFormat": "uploads (ok)"
+          },
+          {
+            "expr": "sum(rate(gateway_uploads_total{status=\"error\"}[5m]))",
+            "legendFormat": "uploads (error)"
+          },
+          {
+            "expr": "sum(rate(gateway_downloads_total{status=\"success\"}[5m]))",
+            "legendFormat": "downloads (ok)"
+          },
+          {
+            "expr": "sum(rate(gateway_downloads_total{status=\"error\"}[5m]))",
+            "legendFormat": "downloads (error)"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 10
+            }
+          }
+        }
+      },
+      {
+        "id": 21,
+        "title": "Stamp Purchases & Pool Acquires",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+        "targets": [
+          {
+            "expr": "sum(rate(gateway_stamp_purchases_total{status=\"success\"}[5m]))",
+            "legendFormat": "purchases (ok)"
+          },
+          {
+            "expr": "sum(rate(gateway_stamp_purchases_total{status=\"error\"}[5m]))",
+            "legendFormat": "purchases (error)"
+          },
+          {
+            "expr": "sum(rate(gateway_pool_acquires_total{status=\"success\"}[5m]))",
+            "legendFormat": "pool acquires (ok)"
+          },
+          {
+            "expr": "sum(rate(gateway_pool_acquires_total{status=\"error\"}[5m]))",
+            "legendFormat": "pool acquires (error)"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 10
+            }
+          }
+        }
+      },
+      {
+        "id": 30,
+        "title": "BZZ Balance",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 0, "y": 20 },
+        "targets": [
+          {
+            "expr": "gateway_wallet_bzz_balance",
+            "legendFormat": "BZZ"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "gradientMode": "scheme"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "yellow" },
+                { "value": 5, "color": "green" }
+              ]
+            },
+            "color": { "mode": "continuous-GrYlRd" }
+          }
+        }
+      },
+      {
+        "id": 31,
+        "title": "xDAI Balance",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 6, "y": 20 },
+        "targets": [
+          {
+            "expr": "gateway_wallet_xdai_balance",
+            "legendFormat": "xDAI"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "gradientMode": "scheme"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 0.1, "color": "yellow" },
+                { "value": 0.5, "color": "green" }
+              ]
+            },
+            "color": { "mode": "continuous-GrYlRd" }
+          }
+        }
+      },
+      {
+        "id": 32,
+        "title": "Chequebook Balance",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 12, "y": 20 },
+        "targets": [
+          {
+            "expr": "gateway_chequebook_available_balance",
+            "legendFormat": "Chequebook BZZ"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "gradientMode": "scheme"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "yellow" },
+                { "value": 5, "color": "green" }
+              ]
+            },
+            "color": { "mode": "continuous-GrYlRd" }
+          }
+        }
+      },
+      {
+        "id": 33,
+        "title": "Base ETH Balance",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 6, "x": 18, "y": 20 },
+        "targets": [
+          {
+            "expr": "gateway_base_eth_balance",
+            "legendFormat": "ETH (Base)"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "decimals": 6,
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20,
+              "gradientMode": "scheme"
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 0.001, "color": "yellow" },
+                { "value": 0.005, "color": "green" }
+              ]
+            },
+            "color": { "mode": "continuous-GrYlRd" }
+          }
+        }
+      },
+      {
+        "id": 40,
+        "title": "Stamp Pool Available",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
+        "targets": [
+          {
+            "expr": "gateway_stamp_pool_available",
+            "legendFormat": "{{size}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": {
+              "drawStyle": "bars",
+              "fillOpacity": 50
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 1, "color": "green" }
+              ]
+            }
+          }
+        }
+      },
+      {
+        "id": 41,
+        "title": "Total Stamps on Bee Node",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
+        "targets": [
+          {
+            "expr": "gateway_stamps_total",
+            "legendFormat": "stamps"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "short",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 15
+            }
+          }
+        }
+      },
+      {
+        "id": 42,
+        "title": "Min Stamp TTL",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
+        "targets": [
+          {
+            "expr": "gateway_stamp_min_ttl_seconds / 3600",
+            "legendFormat": "min TTL (hours)"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "h",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 15
+            },
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                { "value": null, "color": "red" },
+                { "value": 24, "color": "yellow" },
+                { "value": 72, "color": "green" }
+              ]
+            },
+            "color": { "mode": "continuous-GrYlRd" }
+          }
+        }
+      },
+      {
+        "id": 50,
+        "title": "x402 Payment Modes",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+        "targets": [
+          {
+            "expr": "sum(rate(gateway_x402_payments_total[5m])) by (mode)",
+            "legendFormat": "{{mode}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 20
+            }
+          }
+        }
+      },
+      {
+        "id": 51,
+        "title": "Rate Limit Hits",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+        "targets": [
+          {
+            "expr": "rate(gateway_rate_limit_hits_total[5m])",
+            "legendFormat": "rate limit hits/s"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "fillOpacity": 20
+            },
+            "color": { "fixedColor": "orange", "mode": "fixed" }
+          }
+        }
+      }
+    ],
+    "schemaVersion": 39
+  },
+  "overwrite": true
+}

--- a/monitoring/provisioning/dashboards/gateway-overview.json
+++ b/monitoring/provisioning/dashboards/gateway-overview.json
@@ -3,13 +3,11 @@
     "id": null,
     "uid": "gateway-overview",
     "title": "Provenance Gateway Overview",
+    "description": "Operational dashboard for the Provenance Gateway (swarm_connect). Shows request traffic, latency, wallet balances, stamp pool status, x402 payments, and Bee node health. Use the Environment dropdown to filter by deployment (development/main).",
     "tags": ["gateway", "provenance"],
     "timezone": "browser",
     "refresh": "15s",
-    "time": {
-      "from": "now-1h",
-      "to": "now"
-    },
+    "time": { "from": "now-1h", "to": "now" },
     "templating": {
       "list": [
         {
@@ -29,539 +27,158 @@
     },
     "panels": [
       {
-        "id": 1,
-        "title": "Gateway Status",
-        "type": "stat",
+        "id": 1, "title": "Gateway Status", "type": "stat",
+        "description": "Whether the gateway process is up and responding to /metrics scrapes. GREEN = up, RED = down.",
         "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
-        "targets": [
-          {
-            "expr": "up{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "mappings": [
-              { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
-            ],
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "up{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }], "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "green" }] } } }
       },
       {
-        "id": 2,
-        "title": "Uptime",
-        "type": "stat",
+        "id": 2, "title": "Uptime", "type": "stat",
+        "description": "How long the gateway process has been running since last restart. Resets on deploy.",
         "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
-        "targets": [
-          {
-            "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "h",
-            "decimals": 1,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "h", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }] } } }
       },
       {
-        "id": 3,
-        "title": "Request Rate",
-        "type": "stat",
+        "id": 3, "title": "Request Rate", "type": "stat",
+        "description": "Total HTTP requests per second across all endpoints (5-minute average).",
         "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(rate(http_requests_total{environment=~\"$environment\"}[5m]))",
-            "legendFormat": "req/s"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "decimals": 2,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "blue" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(http_requests_total{environment=~\"$environment\"}[5m]))", "legendFormat": "req/s" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "decimals": 2, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "blue" }] } } }
       },
       {
-        "id": 4,
-        "title": "Error Rate",
-        "type": "stat",
+        "id": 4, "title": "Error Rate", "type": "stat",
+        "description": "Percentage of requests returning 5xx errors (5-minute average). >1% = warning, >5% = critical.",
         "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=~\"$environment\"}[5m])) * 100 or vector(0)",
-            "legendFormat": "5xx %"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "percent",
-            "decimals": 1,
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "green" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "red" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=~\"$environment\"}[5m])) * 100 or vector(0)", "legendFormat": "5xx %" }],
+        "fieldConfig": { "defaults": { "unit": "percent", "decimals": 1, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "red" }] } } }
       },
       {
-        "id": 5,
-        "title": "Total Uploads",
-        "type": "stat",
+        "id": 5, "title": "Total Uploads", "type": "stat",
+        "description": "Total successful data uploads (POST /api/v1/data/) since last gateway restart.",
         "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
-            "legendFormat": "uploads"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "purple" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "uploads" }],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "purple" }] } } }
       },
       {
-        "id": 6,
-        "title": "Total Downloads",
-        "type": "stat",
+        "id": 6, "title": "Total Downloads", "type": "stat",
+        "description": "Total successful data downloads (GET /api/v1/data/{ref}) since last gateway restart.",
         "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
-        "targets": [
-          {
-            "expr": "sum(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
-            "legendFormat": "downloads"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "blue" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "downloads" }],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "blue" }] } } }
       },
       {
-        "id": 10,
-        "title": "Request Rate by Endpoint",
-        "type": "timeseries",
+        "id": 10, "title": "Request Rate by Endpoint", "type": "timeseries",
+        "description": "Requests per second broken down by API endpoint. Shows which endpoints are busiest. The /health endpoint is typically the most frequent due to healthchecks.",
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
-        "targets": [
-          {
-            "expr": "sum by (handler) (rate(http_requests_total{environment=~\"$environment\"}[5m]))",
-            "legendFormat": "{{handler}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "targets": [{ "expr": "sum by (handler) (rate(http_requests_total{environment=~\"$environment\"}[5m]))", "legendFormat": "{{handler}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 11,
-        "title": "Latency p50 / p95 / p99",
-        "type": "timeseries",
+        "id": 11, "title": "Latency p50 / p95 / p99", "type": "timeseries",
+        "description": "Response time percentiles across all endpoints. p50 = median, p95 = 95th percentile (most users), p99 = tail latency. Spikes indicate Bee node slowness or heavy payloads.",
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
         "targets": [
-          {
-            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p50"
-          },
-          {
-            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p95"
-          },
-          {
-            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
-            "legendFormat": "p99"
-          }
+          { "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p50" },
+          { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p95" },
+          { "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))", "legendFormat": "p99" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "s",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 5
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 5 } } }
       },
       {
-        "id": 20,
-        "title": "Uploads & Downloads",
-        "type": "timeseries",
+        "id": 20, "title": "Uploads & Downloads", "type": "timeseries",
+        "description": "Rate of data upload and download operations. 'error' lines indicate failed Bee node calls, stamp validation failures, or file size rejections.",
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
         "targets": [
-          {
-            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "uploads (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "uploads (error)"
-          },
-          {
-            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "downloads (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "downloads (error)"
-          }
+          { "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "uploads (ok)" },
+          { "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "uploads (error)" },
+          { "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "downloads (ok)" },
+          { "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "downloads (error)" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 21,
-        "title": "Stamp Purchases & Pool Acquires",
-        "type": "timeseries",
+        "id": 21, "title": "Stamp Purchases & Pool Acquires", "type": "timeseries",
+        "description": "Rate of stamp purchases (POST /stamps/) and pool acquisitions (POST /pool/acquire). Pool acquires are instant (<5s) while direct purchases take >1 minute. Errors indicate insufficient funds or Bee node issues.",
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
         "targets": [
-          {
-            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "purchases (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "purchases (error)"
-          },
-          {
-            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))",
-            "legendFormat": "pool acquires (ok)"
-          },
-          {
-            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}[5m]))",
-            "legendFormat": "pool acquires (error)"
-          }
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "purchases (ok)" },
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "purchases (error)" },
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "pool acquires (ok)" },
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "pool acquires (error)" }
         ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 10
-            }
-          }
-        }
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 10 } } }
       },
       {
-        "id": 30,
-        "title": "BZZ Balance",
-        "type": "timeseries",
+        "id": 30, "title": "BZZ Balance", "type": "timeseries",
+        "description": "Bee node wallet BZZ balance (for purchasing stamps). RED <1 BZZ (critical), YELLOW <5 BZZ (warning), GREEN >5 BZZ. Drops when stamps are purchased.",
         "gridPos": { "h": 8, "w": 6, "x": 0, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_wallet_bzz_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_wallet_bzz_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 31,
-        "title": "xDAI Balance",
-        "type": "timeseries",
+        "id": 31, "title": "xDAI Balance", "type": "timeseries",
+        "description": "Bee node xDAI balance (gas for Gnosis chain transactions). RED <0.1 xDAI (critical), YELLOW <0.5 xDAI (warning). Needed for stamp purchases and chequebook operations.",
         "gridPos": { "h": 8, "w": 6, "x": 6, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_wallet_xdai_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 0.1, "color": "yellow" },
-                { "value": 0.5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_wallet_xdai_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 0.1, "color": "yellow" }, { "value": 0.5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 32,
-        "title": "Chequebook Balance",
-        "type": "timeseries",
+        "id": 32, "title": "Chequebook Balance", "type": "timeseries",
+        "description": "Chequebook available BZZ balance (for bandwidth payments to other Bee nodes). RED <1 BZZ, YELLOW <5 BZZ. Depletes as data is uploaded/downloaded from the Swarm network.",
         "gridPos": { "h": 8, "w": 6, "x": 12, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_chequebook_available_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "yellow" },
-                { "value": 5, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_chequebook_available_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "yellow" }, { "value": 5, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 33,
-        "title": "Base ETH Balance",
-        "type": "timeseries",
+        "id": 33, "title": "Base ETH Balance", "type": "timeseries",
+        "description": "Gateway wallet ETH on Base chain (gas for x402 USDC settlement). RED <0.001 ETH (~10 txs, critical), YELLOW <0.005 ETH (~50 txs). Only relevant when x402 payments are enabled.",
         "gridPos": { "h": 8, "w": 6, "x": 18, "y": 20 },
-        "targets": [
-          {
-            "expr": "gateway_base_eth_balance{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "decimals": 6,
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20,
-              "gradientMode": "scheme"
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 0.001, "color": "yellow" },
-                { "value": 0.005, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_base_eth_balance{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "decimals": 6, "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 0.001, "color": "yellow" }, { "value": 0.005, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 40,
-        "title": "Stamp Pool Available",
-        "type": "timeseries",
+        "id": 40, "title": "Stamp Pool Available", "type": "timeseries",
+        "description": "Number of pre-purchased stamps available in the pool by size (small/medium/large). When this hits 0, pool acquire requests return 409 and users must purchase stamps directly (~1 min wait).",
         "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamp_pool_available{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}} — {{size}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "bars",
-              "fillOpacity": 50
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 1, "color": "green" }
-              ]
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamp_pool_available{environment=~\"$environment\"}", "legendFormat": "{{environment}} — {{size}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "bars", "fillOpacity": 50 }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 1, "color": "green" }] } } }
       },
       {
-        "id": 41,
-        "title": "Total Stamps on Bee Node",
-        "type": "timeseries",
+        "id": 41, "title": "Total Stamps on Bee Node", "type": "timeseries",
+        "description": "Total number of postage stamps on the connected Bee node. Includes pool stamps, user-purchased stamps, and any pre-existing stamps.",
         "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamps_total{environment=~\"$environment\"}",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "short",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 15
-            }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamps_total{environment=~\"$environment\"}", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 15 } } }
       },
       {
-        "id": 42,
-        "title": "Min Stamp TTL",
-        "type": "timeseries",
+        "id": 42, "title": "Min Stamp TTL", "type": "timeseries",
+        "description": "Lowest time-to-live among all active stamps (in hours). RED <24h (expiring soon), YELLOW <72h. When stamps expire, data stored with them becomes unretrievable.",
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
-        "targets": [
-          {
-            "expr": "gateway_stamp_min_ttl_seconds{environment=~\"$environment\"} / 3600",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "h",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 15
-            },
-            "thresholds": {
-              "mode": "absolute",
-              "steps": [
-                { "value": null, "color": "red" },
-                { "value": 24, "color": "yellow" },
-                { "value": 72, "color": "green" }
-              ]
-            },
-            "color": { "mode": "continuous-GrYlRd" }
-          }
-        }
+        "targets": [{ "expr": "gateway_stamp_min_ttl_seconds{environment=~\"$environment\"} / 3600", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "h", "custom": { "drawStyle": "line", "fillOpacity": 15 }, "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "red" }, { "value": 24, "color": "yellow" }, { "value": 72, "color": "green" }] }, "color": { "mode": "continuous-GrYlRd" } } }
       },
       {
-        "id": 50,
-        "title": "x402 Payment Modes",
-        "type": "timeseries",
+        "id": 50, "title": "x402 Payment Modes", "type": "timeseries",
+        "description": "Rate of x402 payment requests by mode. 'paid' = USDC payment verified, 'free' = free tier access granted, 'rejected' = no payment provided (402 returned). Only active when X402_ENABLED=true.",
         "gridPos": { "h": 8, "w": 8, "x": 0, "y": 36 },
-        "targets": [
-          {
-            "expr": "sum(rate(gateway_x402_payments_total{environment=~\"$environment\"}[5m])) by (mode)",
-            "legendFormat": "{{mode}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 20
-            }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(gateway_x402_payments_total{environment=~\"$environment\"}[5m])) by (mode)", "legendFormat": "{{mode}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 } } }
       },
       {
-        "id": 51,
-        "title": "Rate Limit Hits",
-        "type": "timeseries",
+        "id": 51, "title": "Rate Limit Hits", "type": "timeseries",
+        "description": "Rate of 429 Too Many Requests responses from the global rate limiter. High values indicate aggressive clients or insufficient rate limit configuration. Only active when X402_ENABLED=false (x402 has its own limiter).",
         "gridPos": { "h": 8, "w": 8, "x": 8, "y": 36 },
-        "targets": [
-          {
-            "expr": "rate(gateway_rate_limit_hits_total{environment=~\"$environment\"}[5m])",
-            "legendFormat": "{{environment}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "fillOpacity": 20
-            },
-            "color": { "fixedColor": "orange", "mode": "fixed" }
-          }
-        }
+        "targets": [{ "expr": "rate(gateway_rate_limit_hits_total{environment=~\"$environment\"}[5m])", "legendFormat": "{{environment}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 20 }, "color": { "fixedColor": "orange", "mode": "fixed" } } }
       },
       {
-        "id": 52,
-        "title": "Bee API Errors",
-        "type": "timeseries",
+        "id": 52, "title": "Bee API Errors", "type": "timeseries",
+        "description": "Rate of failed HTTP requests to the upstream Bee node, by endpoint (batches, upload, download, purchase, wallet). Sustained errors indicate the Bee node is down or unreachable. Check /health for specific error messages.",
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 36 },
-        "targets": [
-          {
-            "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)",
-            "legendFormat": "{{endpoint}}"
-          }
-        ],
-        "fieldConfig": {
-          "defaults": {
-            "unit": "reqps",
-            "custom": {
-              "drawStyle": "line",
-              "lineInterpolation": "smooth",
-              "fillOpacity": 20
-            },
-            "color": { "fixedColor": "red", "mode": "fixed" }
-          }
-        }
+        "targets": [{ "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 }, "color": { "fixedColor": "red", "mode": "fixed" } } }
       }
     ],
     "schemaVersion": 39

--- a/monitoring/provisioning/dashboards/gateway-overview.json
+++ b/monitoring/provisioning/dashboards/gateway-overview.json
@@ -179,6 +179,131 @@
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 36 },
         "targets": [{ "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)", "legendFormat": "{{endpoint}}" }],
         "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 20 }, "color": { "fixedColor": "red", "mode": "fixed" } } }
+      },
+      {
+        "id": 60, "title": "Total Stamps Provisioned (cumulative)", "type": "stat",
+        "description": "Total stamps provisioned since last restart, split by method. Direct = POST /stamps/ (slow, ~1 min). Pool = POST /pool/acquire (instant, <5s).",
+        "gridPos": { "h": 4, "w": 8, "x": 0, "y": 44 },
+        "targets": [
+          { "expr": "sum(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "direct purchases" },
+          { "expr": "sum(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}) or vector(0)", "legendFormat": "pool acquires" }
+        ],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }] } } },
+        "options": { "graphMode": "none", "textMode": "value_and_name" }
+      },
+      {
+        "id": 61, "title": "Stamps by Size (cumulative)", "type": "stat",
+        "description": "Total stamps provisioned by size preset since last restart. Combines both direct purchases and pool acquires.",
+        "gridPos": { "h": 4, "w": 8, "x": 8, "y": 44 },
+        "targets": [
+          { "expr": "sum(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}) by (size) + (sum(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}) by (size) or vector(0))", "legendFormat": "{{size}}" }
+        ],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "blue" }] } } },
+        "options": { "graphMode": "none", "textMode": "value_and_name" }
+      },
+      {
+        "id": 62, "title": "Stamp Provision Failures (cumulative)", "type": "stat",
+        "description": "Failed stamp provisioning attempts. Direct failures = insufficient funds or Bee node errors. Pool failures = pool exhausted (409).",
+        "gridPos": { "h": 4, "w": 8, "x": 16, "y": 44 },
+        "targets": [
+          { "expr": "sum(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}) or vector(0)", "legendFormat": "direct failures" },
+          { "expr": "sum(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}) or vector(0)", "legendFormat": "pool failures" }
+        ],
+        "fieldConfig": { "defaults": { "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "green" }, { "value": 1, "color": "red" }] } } },
+        "options": { "graphMode": "none", "textMode": "value_and_name" }
+      },
+      {
+        "id": 63, "title": "Direct Purchases by Size", "type": "timeseries",
+        "description": "Rate of direct stamp purchases (POST /stamps/) by size preset over time. These take ~1 minute due to blockchain confirmation.",
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 48 },
+        "targets": [
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m])) by (size)", "legendFormat": "{{size}}" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } } } }
+      },
+      {
+        "id": 64, "title": "Pool Acquires by Size", "type": "timeseries",
+        "description": "Rate of pool stamp acquisitions (POST /pool/acquire) by size preset over time. Instant delivery (<5s) from pre-purchased pool.",
+        "gridPos": { "h": 8, "w": 8, "x": 8, "y": 48 },
+        "targets": [
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m])) by (size)", "legendFormat": "{{size}}" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "bars", "fillOpacity": 50, "stacking": { "mode": "normal" } } } }
+      },
+      {
+        "id": 65, "title": "Pool vs Direct (total rate)", "type": "timeseries",
+        "description": "Comparison of stamp provisioning methods over time. Ideally most stamps come from the pool (instant) rather than direct purchases (slow).",
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 48 },
+        "targets": [
+          { "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "direct purchases" },
+          { "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "pool acquires" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 30, "stacking": { "mode": "normal" } } } }
+      },
+      {
+        "id": 70, "title": "Data Volume Uploaded", "type": "timeseries",
+        "description": "Rate of data uploaded to the gateway in bytes per second. Spikes indicate large uploads or batch operations.",
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 56 },
+        "targets": [
+          { "expr": "rate(gateway_upload_bytes_total{environment=~\"$environment\"}[5m])", "legendFormat": "{{environment}}" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "Bps", "custom": { "drawStyle": "line", "fillOpacity": 20, "gradientMode": "scheme" }, "color": { "mode": "continuous-blues" } } }
+      },
+      {
+        "id": 71, "title": "HTTP Status Code Breakdown", "type": "timeseries",
+        "description": "Request rate by HTTP status code group. 2xx = success, 4xx = client error (bad input, auth), 5xx = server error (Bee node issues). Useful for spotting spikes in specific error types.",
+        "gridPos": { "h": 8, "w": 8, "x": 8, "y": 56 },
+        "targets": [
+          { "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"2..\"}[5m]))", "legendFormat": "2xx" },
+          { "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"4..\"}[5m]))", "legendFormat": "4xx" },
+          { "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m]))", "legendFormat": "5xx" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 15 } }, "overrides": [
+          { "matcher": { "id": "byName", "options": "2xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "4xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "yellow", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "5xx" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ] }
+      },
+      {
+        "id": 72, "title": "Latency by Endpoint (p95)", "type": "timeseries",
+        "description": "95th percentile response time per endpoint. Identifies which API handlers are slowest. Upload/download endpoints are typically slower due to Bee node I/O.",
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 56 },
+        "targets": [
+          { "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{environment=~\"$environment\"}[5m])) by (le, handler))", "legendFormat": "{{handler}}" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "lineInterpolation": "smooth", "fillOpacity": 5 } } }
+      },
+      {
+        "id": 73, "title": "Notary Signing", "type": "timeseries",
+        "description": "Rate of notary signing operations (POST /data/?sign=notary). Shows successful signatures and failures (not enabled, bad document format). Only active when NOTARY_ENABLED=true.",
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 64 },
+        "targets": [
+          { "expr": "sum(rate(gateway_notary_signatures_total{environment=~\"$environment\",status=\"success\"}[5m]))", "legendFormat": "signed" },
+          { "expr": "sum(rate(gateway_notary_signatures_total{environment=~\"$environment\",status=\"error\"}[5m]))", "legendFormat": "errors" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 15 } }, "overrides": [
+          { "matcher": { "id": "byName", "options": "signed" }, "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }] },
+          { "matcher": { "id": "byName", "options": "errors" }, "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }] }
+        ] }
+      },
+      {
+        "id": 74, "title": "Gateway Version", "type": "stat",
+        "description": "Current gateway version and configuration. Version resets on deploy — use Uptime panel to see when last deploy happened.",
+        "gridPos": { "h": 4, "w": 12, "x": 8, "y": 64 },
+        "targets": [
+          { "expr": "gateway_info{environment=~\"$environment\"}", "legendFormat": "{{environment}}: v{{version}} | x402={{x402_enabled}} pool={{pool_enabled}} notary={{notary_enabled}}" }
+        ],
+        "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "1": { "text": "" } } }], "thresholds": { "mode": "absolute", "steps": [{ "value": null, "color": "transparent" }] } } },
+        "options": { "graphMode": "none", "textMode": "name", "colorMode": "none" }
+      },
+      {
+        "id": 75, "title": "Uptime (deploy history)", "type": "timeseries",
+        "description": "Gateway uptime in hours. Each drop to zero marks a deploy or restart. Useful for correlating metric changes with deployments.",
+        "gridPos": { "h": 4, "w": 4, "x": 20, "y": 64 },
+        "targets": [
+          { "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600", "legendFormat": "{{environment}}" }
+        ],
+        "fieldConfig": { "defaults": { "unit": "h", "custom": { "drawStyle": "line", "fillOpacity": 10 }, "color": { "fixedColor": "green", "mode": "fixed" } } }
       }
     ],
     "schemaVersion": 39

--- a/monitoring/provisioning/dashboards/gateway-overview.json
+++ b/monitoring/provisioning/dashboards/gateway-overview.json
@@ -10,6 +10,23 @@
       "from": "now-1h",
       "to": "now"
     },
+    "templating": {
+      "list": [
+        {
+          "name": "environment",
+          "label": "Environment",
+          "type": "query",
+          "datasource": { "type": "prometheus", "uid": "grafanacloud-prom" },
+          "query": "label_values(gateway_info, environment)",
+          "current": { "text": "All", "value": "$__all" },
+          "includeAll": true,
+          "allValue": ".*",
+          "multi": true,
+          "refresh": 2,
+          "sort": 1
+        }
+      ]
+    },
     "panels": [
       {
         "id": 1,
@@ -18,7 +35,7 @@
         "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
         "targets": [
           {
-            "expr": "up{job=\"provenance-gateway\"}",
+            "expr": "up{environment=~\"$environment\"}",
             "legendFormat": "{{environment}}"
           }
         ],
@@ -44,8 +61,8 @@
         "gridPos": { "h": 4, "w": 4, "x": 4, "y": 0 },
         "targets": [
           {
-            "expr": "gateway_uptime_seconds / 3600",
-            "legendFormat": "hours"
+            "expr": "gateway_uptime_seconds{environment=~\"$environment\"} / 3600",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -68,7 +85,7 @@
         "gridPos": { "h": 4, "w": 4, "x": 8, "y": 0 },
         "targets": [
           {
-            "expr": "sum(rate(http_requests_total[5m]))",
+            "expr": "sum(rate(http_requests_total{environment=~\"$environment\"}[5m]))",
             "legendFormat": "req/s"
           }
         ],
@@ -92,7 +109,7 @@
         "gridPos": { "h": 4, "w": 4, "x": 12, "y": 0 },
         "targets": [
           {
-            "expr": "sum(rate(http_requests_total{status=~\"5..\"}[5m])) / sum(rate(http_requests_total[5m])) * 100 or vector(0)",
+            "expr": "sum(rate(http_requests_total{environment=~\"$environment\",status=~\"5..\"}[5m])) / sum(rate(http_requests_total{environment=~\"$environment\"}[5m])) * 100 or vector(0)",
             "legendFormat": "5xx %"
           }
         ],
@@ -118,7 +135,7 @@
         "gridPos": { "h": 4, "w": 4, "x": 16, "y": 0 },
         "targets": [
           {
-            "expr": "gateway_uploads_total{status=\"success\"} or vector(0)",
+            "expr": "sum(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
             "legendFormat": "uploads"
           }
         ],
@@ -140,7 +157,7 @@
         "gridPos": { "h": 4, "w": 4, "x": 20, "y": 0 },
         "targets": [
           {
-            "expr": "gateway_downloads_total{status=\"success\"} or vector(0)",
+            "expr": "sum(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}) or vector(0)",
             "legendFormat": "downloads"
           }
         ],
@@ -162,7 +179,7 @@
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
         "targets": [
           {
-            "expr": "sum by (handler) (rate(http_requests_total[5m]))",
+            "expr": "sum by (handler) (rate(http_requests_total{environment=~\"$environment\"}[5m]))",
             "legendFormat": "{{handler}}"
           }
         ],
@@ -184,15 +201,15 @@
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
         "targets": [
           {
-            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
             "legendFormat": "p50"
           },
           {
-            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
             "legendFormat": "p95"
           },
           {
-            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket[5m])) by (le))",
+            "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_highr_seconds_bucket{environment=~\"$environment\"}[5m])) by (le))",
             "legendFormat": "p99"
           }
         ],
@@ -214,19 +231,19 @@
         "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
         "targets": [
           {
-            "expr": "sum(rate(gateway_uploads_total{status=\"success\"}[5m]))",
+            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
             "legendFormat": "uploads (ok)"
           },
           {
-            "expr": "sum(rate(gateway_uploads_total{status=\"error\"}[5m]))",
+            "expr": "sum(rate(gateway_uploads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
             "legendFormat": "uploads (error)"
           },
           {
-            "expr": "sum(rate(gateway_downloads_total{status=\"success\"}[5m]))",
+            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"success\"}[5m]))",
             "legendFormat": "downloads (ok)"
           },
           {
-            "expr": "sum(rate(gateway_downloads_total{status=\"error\"}[5m]))",
+            "expr": "sum(rate(gateway_downloads_total{environment=~\"$environment\",status=\"error\"}[5m]))",
             "legendFormat": "downloads (error)"
           }
         ],
@@ -248,19 +265,19 @@
         "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
         "targets": [
           {
-            "expr": "sum(rate(gateway_stamp_purchases_total{status=\"success\"}[5m]))",
+            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"success\"}[5m]))",
             "legendFormat": "purchases (ok)"
           },
           {
-            "expr": "sum(rate(gateway_stamp_purchases_total{status=\"error\"}[5m]))",
+            "expr": "sum(rate(gateway_stamp_purchases_total{environment=~\"$environment\",status=\"error\"}[5m]))",
             "legendFormat": "purchases (error)"
           },
           {
-            "expr": "sum(rate(gateway_pool_acquires_total{status=\"success\"}[5m]))",
+            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"success\"}[5m]))",
             "legendFormat": "pool acquires (ok)"
           },
           {
-            "expr": "sum(rate(gateway_pool_acquires_total{status=\"error\"}[5m]))",
+            "expr": "sum(rate(gateway_pool_acquires_total{environment=~\"$environment\",status=\"error\"}[5m]))",
             "legendFormat": "pool acquires (error)"
           }
         ],
@@ -282,8 +299,8 @@
         "gridPos": { "h": 8, "w": 6, "x": 0, "y": 20 },
         "targets": [
           {
-            "expr": "gateway_wallet_bzz_balance",
-            "legendFormat": "BZZ"
+            "expr": "gateway_wallet_bzz_balance{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -313,8 +330,8 @@
         "gridPos": { "h": 8, "w": 6, "x": 6, "y": 20 },
         "targets": [
           {
-            "expr": "gateway_wallet_xdai_balance",
-            "legendFormat": "xDAI"
+            "expr": "gateway_wallet_xdai_balance{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -344,8 +361,8 @@
         "gridPos": { "h": 8, "w": 6, "x": 12, "y": 20 },
         "targets": [
           {
-            "expr": "gateway_chequebook_available_balance",
-            "legendFormat": "Chequebook BZZ"
+            "expr": "gateway_chequebook_available_balance{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -375,8 +392,8 @@
         "gridPos": { "h": 8, "w": 6, "x": 18, "y": 20 },
         "targets": [
           {
-            "expr": "gateway_base_eth_balance",
-            "legendFormat": "ETH (Base)"
+            "expr": "gateway_base_eth_balance{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -407,8 +424,8 @@
         "gridPos": { "h": 8, "w": 8, "x": 0, "y": 28 },
         "targets": [
           {
-            "expr": "gateway_stamp_pool_available",
-            "legendFormat": "{{size}}"
+            "expr": "gateway_stamp_pool_available{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}} — {{size}}"
           }
         ],
         "fieldConfig": {
@@ -435,8 +452,8 @@
         "gridPos": { "h": 8, "w": 8, "x": 8, "y": 28 },
         "targets": [
           {
-            "expr": "gateway_stamps_total",
-            "legendFormat": "stamps"
+            "expr": "gateway_stamps_total{environment=~\"$environment\"}",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -456,8 +473,8 @@
         "gridPos": { "h": 8, "w": 8, "x": 16, "y": 28 },
         "targets": [
           {
-            "expr": "gateway_stamp_min_ttl_seconds / 3600",
-            "legendFormat": "min TTL (hours)"
+            "expr": "gateway_stamp_min_ttl_seconds{environment=~\"$environment\"} / 3600",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -483,10 +500,10 @@
         "id": 50,
         "title": "x402 Payment Modes",
         "type": "timeseries",
-        "gridPos": { "h": 8, "w": 12, "x": 0, "y": 36 },
+        "gridPos": { "h": 8, "w": 8, "x": 0, "y": 36 },
         "targets": [
           {
-            "expr": "sum(rate(gateway_x402_payments_total[5m])) by (mode)",
+            "expr": "sum(rate(gateway_x402_payments_total{environment=~\"$environment\"}[5m])) by (mode)",
             "legendFormat": "{{mode}}"
           }
         ],
@@ -505,11 +522,11 @@
         "id": 51,
         "title": "Rate Limit Hits",
         "type": "timeseries",
-        "gridPos": { "h": 8, "w": 12, "x": 12, "y": 36 },
+        "gridPos": { "h": 8, "w": 8, "x": 8, "y": 36 },
         "targets": [
           {
-            "expr": "rate(gateway_rate_limit_hits_total[5m])",
-            "legendFormat": "rate limit hits/s"
+            "expr": "rate(gateway_rate_limit_hits_total{environment=~\"$environment\"}[5m])",
+            "legendFormat": "{{environment}}"
           }
         ],
         "fieldConfig": {
@@ -520,6 +537,29 @@
               "fillOpacity": 20
             },
             "color": { "fixedColor": "orange", "mode": "fixed" }
+          }
+        }
+      },
+      {
+        "id": 52,
+        "title": "Bee API Errors",
+        "type": "timeseries",
+        "gridPos": { "h": 8, "w": 8, "x": 16, "y": 36 },
+        "targets": [
+          {
+            "expr": "sum(rate(gateway_bee_api_errors_total{environment=~\"$environment\"}[5m])) by (endpoint)",
+            "legendFormat": "{{endpoint}}"
+          }
+        ],
+        "fieldConfig": {
+          "defaults": {
+            "unit": "reqps",
+            "custom": {
+              "drawStyle": "line",
+              "lineInterpolation": "smooth",
+              "fillOpacity": 20
+            },
+            "color": { "fixedColor": "red", "mode": "fixed" }
           }
         }
       }

--- a/monitoring/provisioning/dashboards/provider.yml
+++ b/monitoring/provisioning/dashboards/provider.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "default"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/provisioning/datasources/prometheus.yml
+++ b/monitoring/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,10 @@ python-multipart>=0.0.20  # For file upload support in FastAPI
 x402==1.0.0               # Official x402 Python SDK (pinned - v2.x has breaking API changes)
 eth-account>=0.8.0        # For wallet signature verification
 
+# Prometheus monitoring
+prometheus-fastapi-instrumentator>=6.0.0
+prometheus_client>=0.19.0
+
 # Testing dependencies
 pytest>=7.0.0
 pytest-asyncio>=0.21.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,362 @@
+# tests/test_metrics.py
+"""
+Tests for Prometheus metrics endpoint and custom metrics (Issue #180-#183).
+"""
+import os
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+# Ensure test environment settings
+os.environ.setdefault("SWARM_BEE_API_URL", "http://localhost:1633")
+os.environ.setdefault("METRICS_ENABLED", "true")
+os.environ.setdefault("GATEWAY_ENVIRONMENT", "test")
+
+from fastapi.testclient import TestClient
+from prometheus_client import REGISTRY
+
+
+class TestMetricsEndpoint:
+    """Tests for the /metrics endpoint."""
+
+    def test_metrics_endpoint_returns_200(self):
+        """GET /metrics returns 200 with Prometheus text format."""
+        from app.main import app
+        client = TestClient(app)
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        # Prometheus text format contains HELP and TYPE lines
+        assert "# HELP" in response.text
+        assert "# TYPE" in response.text
+
+    def test_metrics_contains_http_request_metrics(self):
+        """Auto-instrumented HTTP metrics are present."""
+        from app.main import app
+        client = TestClient(app)
+        # Make a request first to generate metrics
+        client.get("/")
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        # Check for auto-instrumented metrics from prometheus-fastapi-instrumentator
+        assert "http_request" in response.text
+
+    def test_metrics_contains_gateway_info(self):
+        """gateway_info metric is registered and can be set with environment label."""
+        from app.services.metrics import gateway_info
+        # Set info directly (lifespan does this at startup, but may not run in test context)
+        gateway_info.info({
+            "version": "test",
+            "environment": "test",
+            "x402_enabled": "False",
+            "pool_enabled": "False",
+            "notary_enabled": "False",
+        })
+        from app.main import app
+        client = TestClient(app)
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert "gateway_info" in response.text
+        assert 'environment="test"' in response.text
+
+    def test_metrics_contains_custom_counters(self):
+        """Custom counter definitions are registered."""
+        from app.main import app
+        client = TestClient(app)
+        response = client.get("/metrics")
+        text = response.text
+        # Check counter definitions exist
+        assert "gateway_uploads_total" in text
+        assert "gateway_downloads_total" in text
+        assert "gateway_stamp_purchases_total" in text
+        assert "gateway_pool_acquires_total" in text
+        assert "gateway_rate_limit_hits_total" in text
+
+    def test_metrics_contains_custom_gauges(self):
+        """Custom gauge definitions are registered."""
+        from app.main import app
+        client = TestClient(app)
+        response = client.get("/metrics")
+        text = response.text
+        assert "gateway_uptime_seconds" in text
+        assert "gateway_stamps_total" in text
+
+
+class TestMetricsExemptFromRateLimit:
+    """Tests that /metrics is exempt from rate limiting."""
+
+    def test_metrics_in_exempt_paths(self):
+        """The /metrics path is in the exempt paths set."""
+        from app.middleware.rate_limit import EXEMPT_PATHS
+        assert "/metrics" in EXEMPT_PATHS
+
+    def test_is_exempt_path_returns_true(self):
+        """_is_exempt_path returns True for /metrics."""
+        from app.middleware.rate_limit import _is_exempt_path
+        assert _is_exempt_path("/metrics") is True
+
+
+class TestUploadCounters:
+    """Tests that upload operations increment counters."""
+
+    @patch("app.api.endpoints.data.upload_data_to_swarm", new_callable=AsyncMock)
+    @patch("app.api.endpoints.data.stamp_ownership_manager")
+    def test_upload_success_increments_counter(self, mock_ownership, mock_upload):
+        """Successful upload increments gateway_uploads_total{status=success}."""
+        from app.services.metrics import uploads_total, upload_bytes_total
+        mock_upload.return_value = "a" * 64
+        mock_ownership.check_access.return_value = (True, "ok")
+
+        before = uploads_total.labels(status="success")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        import io
+        response = client.post(
+            f"/api/v1/data/?stamp_id={'ab' * 32}",
+            files={"file": ("test.json", io.BytesIO(b'{"test": true}'), "application/json")},
+        )
+        assert response.status_code == 200
+
+        after = uploads_total.labels(status="success")._value.get()
+        assert after > before
+
+    @patch("app.api.endpoints.data.upload_data_to_swarm", new_callable=AsyncMock)
+    @patch("app.api.endpoints.data.stamp_ownership_manager")
+    def test_upload_error_increments_counter(self, mock_ownership, mock_upload):
+        """Failed upload increments gateway_uploads_total{status=error}."""
+        import httpx
+        from app.services.metrics import uploads_total
+        mock_upload.side_effect = httpx.HTTPError("Bee node down")
+        mock_ownership.check_access.return_value = (True, "ok")
+
+        before = uploads_total.labels(status="error")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        import io
+        response = client.post(
+            f"/api/v1/data/?stamp_id={'ab' * 32}",
+            files={"file": ("test.json", io.BytesIO(b'{"test": true}'), "application/json")},
+        )
+        assert response.status_code == 502
+
+        after = uploads_total.labels(status="error")._value.get()
+        assert after > before
+
+
+class TestDownloadCounters:
+    """Tests that download operations increment counters."""
+
+    @patch("app.api.endpoints.data.download_data_from_swarm", new_callable=AsyncMock)
+    def test_download_success_increments_counter(self, mock_download):
+        """Successful download increments gateway_downloads_total{status=success}."""
+        from app.services.metrics import downloads_total
+        mock_download.return_value = b'{"data": "test"}'
+
+        before = downloads_total.labels(status="success")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        response = client.get(f"/api/v1/data/{'ab' * 32}")
+        assert response.status_code == 200
+
+        after = downloads_total.labels(status="success")._value.get()
+        assert after > before
+
+    @patch("app.api.endpoints.data.download_data_from_swarm", new_callable=AsyncMock)
+    def test_download_not_found_increments_error(self, mock_download):
+        """404 download increments gateway_downloads_total{status=error}."""
+        from app.services.metrics import downloads_total
+        mock_download.side_effect = FileNotFoundError("not found")
+
+        before = downloads_total.labels(status="error")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        response = client.get(f"/api/v1/data/{'ab' * 32}")
+        assert response.status_code == 404
+
+        after = downloads_total.labels(status="error")._value.get()
+        assert after > before
+
+
+class TestRateLimitCounter:
+    """Tests that rate limit hits increment the counter."""
+
+    def test_rate_limit_counter_registered(self):
+        """rate_limit_hits_total counter is registered."""
+        from app.services.metrics import rate_limit_hits_total
+        # Simply verify the counter object exists and is callable
+        assert rate_limit_hits_total is not None
+        # Incrementing should not raise
+        rate_limit_hits_total.inc(0)
+
+
+class TestStampPurchaseCounter:
+    """Tests that stamp purchase operations increment counters."""
+
+    @patch("app.api.endpoints.stamps.swarm_api.check_sufficient_funds", new_callable=AsyncMock)
+    @patch("app.api.endpoints.stamps.swarm_api.calculate_stamp_total_cost")
+    @patch("app.api.endpoints.stamps.swarm_api.calculate_stamp_amount")
+    @patch("app.api.endpoints.stamps.swarm_api.get_chainstate", new_callable=AsyncMock)
+    @patch("app.api.endpoints.stamps.swarm_api.purchase_postage_stamp", new_callable=AsyncMock)
+    def test_stamp_purchase_increments_counter(
+        self, mock_purchase, mock_chainstate, mock_calc_amount, mock_calc_cost, mock_funds
+    ):
+        """Successful stamp purchase increments gateway_stamp_purchases_total."""
+        from app.services.metrics import stamp_purchases_total
+        mock_purchase.return_value = "ab" * 32
+        mock_chainstate.return_value = {"currentPrice": "100"}
+        mock_calc_amount.return_value = 10000
+        mock_calc_cost.return_value = 50000
+        mock_funds.return_value = {"sufficient": True}
+
+        before = stamp_purchases_total.labels(size="small", status="success")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        response = client.post(
+            "/api/v1/stamps/",
+            json={"size": "small"},
+        )
+        assert response.status_code == 201
+
+        after = stamp_purchases_total.labels(size="small", status="success")._value.get()
+        assert after > before
+
+
+class TestX402PaymentCounter:
+    """Tests that x402 payment mode counters are defined."""
+
+    def test_x402_payment_counter_registered(self):
+        """x402_payments_total counter exists with expected labels."""
+        from app.services.metrics import x402_payments_total
+        assert x402_payments_total is not None
+        # Labels should not raise
+        x402_payments_total.labels(mode="paid").inc(0)
+        x402_payments_total.labels(mode="free").inc(0)
+        x402_payments_total.labels(mode="rejected").inc(0)
+
+
+class TestBeeApiErrorCounter:
+    """Tests that Bee API errors increment the counter."""
+
+    @patch("app.api.endpoints.data.download_data_from_swarm", new_callable=AsyncMock)
+    def test_download_bee_error_increments_bee_api_counter(self, mock_download):
+        """502 from Bee node increments gateway_bee_api_errors_total."""
+        import httpx
+        from app.services.metrics import bee_api_errors_total
+
+        # Simulate a Bee API error that goes through swarm_api
+        mock_download.side_effect = httpx.HTTPError("Connection refused")
+
+        before = bee_api_errors_total.labels(endpoint="download")._value.get()
+
+        # Call _record_bee_error directly since the mock bypasses swarm_api
+        from app.services.swarm_api import _record_bee_error
+        _record_bee_error("download")
+
+        after = bee_api_errors_total.labels(endpoint="download")._value.get()
+        assert after > before
+
+    def test_bee_api_error_counter_labels(self):
+        """bee_api_errors_total supports expected endpoint labels."""
+        from app.services.metrics import bee_api_errors_total
+        for endpoint in ["batches", "upload", "download", "purchase", "wallet"]:
+            bee_api_errors_total.labels(endpoint=endpoint).inc(0)
+
+
+class TestManifestUploadCounter:
+    """Tests that manifest upload operations increment counters."""
+
+    @patch("app.api.endpoints.data.upload_collection_to_swarm", new_callable=AsyncMock)
+    @patch("app.api.endpoints.data.count_tar_files")
+    @patch("app.api.endpoints.data.validate_tar")
+    @patch("app.api.endpoints.data.stamp_ownership_manager")
+    def test_manifest_upload_increments_counter(
+        self, mock_ownership, mock_validate, mock_count, mock_upload
+    ):
+        """Successful manifest upload increments gateway_uploads_total."""
+        import io
+        import tarfile
+        from app.services.metrics import uploads_total
+
+        mock_upload.return_value = "ab" * 32
+        mock_validate.return_value = None
+        mock_count.return_value = 3
+        mock_ownership.check_access.return_value = (True, "ok")
+
+        # Create a valid tar archive
+        tar_buffer = io.BytesIO()
+        with tarfile.open(fileobj=tar_buffer, mode="w") as tar:
+            data = b'{"test": true}'
+            info = tarfile.TarInfo(name="test.json")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+        tar_bytes = tar_buffer.getvalue()
+
+        before = uploads_total.labels(status="success")._value.get()
+
+        from app.main import app
+        client = TestClient(app)
+        response = client.post(
+            f"/api/v1/data/manifest?stamp_id={'ab' * 32}",
+            files={"file": ("files.tar", io.BytesIO(tar_bytes), "application/x-tar")},
+        )
+        assert response.status_code == 200
+
+        after = uploads_total.labels(status="success")._value.get()
+        assert after > before
+
+
+class TestMetricsBackgroundTask:
+    """Tests for the background balance polling task."""
+
+    @pytest.mark.asyncio
+    async def test_start_stop_background_task(self):
+        """Background task can be started and stopped without error."""
+        from app.services.metrics import (
+            start_metrics_background_task,
+            stop_metrics_background_task,
+        )
+        # Patch the poll function to avoid actual API calls
+        with patch("app.services.metrics._poll_balances", new_callable=AsyncMock):
+            await start_metrics_background_task()
+            await stop_metrics_background_task()
+
+    @pytest.mark.asyncio
+    async def test_poll_updates_gauges(self):
+        """Background poller updates wallet balance gauges."""
+        from app.services.metrics import wallet_bzz_balance, stamps_total, _poll_balances
+        import asyncio
+
+        with patch("app.services.metrics.settings") as mock_settings, \
+             patch("app.services.swarm_api.get_wallet_info", new_callable=AsyncMock) as mock_wallet, \
+             patch("app.services.swarm_api.get_chequebook_info", new_callable=AsyncMock) as mock_cheque, \
+             patch("app.services.swarm_api.get_all_stamps", new_callable=AsyncMock) as mock_stamps:
+
+            mock_settings.X402_ENABLED = False
+            mock_settings.STAMP_POOL_ENABLED = False
+            mock_settings.METRICS_BALANCE_POLL_SECONDS = 0.1
+
+            mock_wallet.return_value = {"bzzBalance": str(5 * 10**16)}  # 5 BZZ
+            mock_cheque.return_value = {"availableBalance": str(3 * 10**16)}
+            mock_stamps.return_value = [{"batchTTL": 86400}, {"batchTTL": 3600}]
+
+            # Run one poll cycle (patch sleep to exit after one iteration)
+            original_sleep = asyncio.sleep
+            call_count = 0
+            async def fake_sleep(seconds):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 1:
+                    raise asyncio.CancelledError()
+                await original_sleep(0)
+
+            with patch("asyncio.sleep", side_effect=fake_sleep):
+                try:
+                    await _poll_balances()
+                except asyncio.CancelledError:
+                    pass
+
+            assert wallet_bzz_balance._value.get() == 5.0
+            assert stamps_total._value.get() == 2.0


### PR DESCRIPTION
## Summary

Promotes all monitoring work from dev to production.

### What's included
- Prometheus `/metrics` endpoint with auto-instrumented HTTP metrics + custom business metrics
- Grafana Alloy sidecar container pushing metrics to Grafana Cloud every 15s
- 23-panel Grafana dashboard at `datafund.grafana.net/d/gateway-overview`
- Stamp pool replenishment 429 retry fix (#176)
- 19 new metrics tests, zero regressions
- Updated CLAUDE.md, README.md, .env.example, deploy.yml

### What happens on merge
1. Deploy builds `swarm_connect:main` image with `/metrics` endpoint
2. Writes Grafana Cloud credentials to `.env` from GitHub secrets
3. Starts 3 containers: production gateway (8899), dev gateway (8900), Alloy
4. Alloy scrapes production gateway and pushes with `environment=main` label
5. "main" appears in the Grafana Cloud dashboard environment dropdown

### Issues addressed
- #179 (monitoring epic), #180-#184 (metrics implementation)
- #185 (Grafana Cloud + Alloy), #176 (pool replenishment fix)