### PR TITLE
Fix pool topup: per-stamp API lookup + debug info

### DIFF
--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -497,17 +497,32 @@ class StampPoolManager:
                     if s.status == PoolStampStatus.AVAILABLE
                 ]
 
+            results["topup_debug"] = []
             for stamp in stamps_to_topup:
                 # Get current TTL from Bee node
                 current_ttl = await self._get_stamp_ttl(stamp.batch_id)
+                debug = {
+                    "stamp": stamp.batch_id[:16],
+                    "ttl_seconds": current_ttl,
+                    "ttl_hours": round(current_ttl / 3600, 1) if current_ttl else None,
+                    "threshold_hours": settings.STAMP_POOL_MIN_TTL_HOURS,
+                    "needs_topup": current_ttl is not None and current_ttl < min_ttl_seconds,
+                }
                 if current_ttl is not None and current_ttl < min_ttl_seconds:
                     try:
                         await self._topup_stamp(stamp.batch_id)
                         results["stamps_topped_up"] += 1
+                        debug["result"] = "topped_up"
                     except Exception as e:
                         error_msg = f"Failed to top up stamp {stamp.batch_id[:16]}...: {e}"
                         logger.error(error_msg)
                         results["errors"].append(error_msg)
+                        debug["result"] = f"error: {e}"
+                elif current_ttl is None:
+                    debug["result"] = "skipped: ttl_lookup_returned_none"
+                else:
+                    debug["result"] = "skipped: above_threshold"
+                results["topup_debug"].append(debug)
 
             self._errors = results["errors"]
 
@@ -602,14 +617,20 @@ class StampPoolManager:
         return False
 
     async def _get_stamp_ttl(self, batch_id: str) -> Optional[int]:
-        """Get current TTL for a stamp."""
+        """Get current TTL for a stamp via direct Bee API lookup."""
         try:
-            stamps = await swarm_api.get_all_stamps_processed()
-            stamp = next((s for s in stamps if s.get("batchID") == batch_id), None)
-            if stamp:
-                return stamp.get("batchTTL", 0)
+            from app.services.http_client import get_client
+            from urllib.parse import urljoin
+            api_url = urljoin(str(settings.SWARM_BEE_API_URL), f"stamps/{batch_id}")
+            client = get_client()
+            response = await client.get(api_url, timeout=10)
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("batchTTL", 0)
+            else:
+                logger.warning(f"Stamp TTL lookup failed for {batch_id[:16]}...: HTTP {response.status_code}")
         except Exception as e:
-            logger.warning(f"Error getting stamp TTL: {e}")
+            logger.warning(f"Error getting stamp TTL for {batch_id[:16]}...: {e}")
         return None
 
     async def _update_stamp_ttls(self):


### PR DESCRIPTION
Two fixes: (1) _get_stamp_ttl now uses direct /stamps/{id} instead of fetching all 567 stamps (timeout fix), (2) /pool/check response includes topup_debug array showing TTL, threshold, and result for each stamp.