### PR TITLE
Write JSON state files atomically to prevent corruption on crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,20 +474,29 @@ feature branches → dev → main
 
 2. **Develop and test locally** on the feature branch
 
-3. **Create PR to merge into `dev`**:
+3. **Run the full test suite locally — MANDATORY before any PR to `dev` or `main`**:
+   ```bash
+   source venv/bin/activate && python -m pytest tests/ -v
+   ```
+   - There is **no CI test gate** — `deploy.yml` only deploys, it does not run pytest. The full suite passing locally is the only thing standing between a regression and staging/production.
+   - **Do not open or merge a PR to `dev` or `main` with failing or broken tests.** If a test is failing, either fix it or, if it is a known pre-existing failure, explicitly call it out in the PR description with a tracking issue — never let it pass silently.
+   - This is a **development-process rule**, enforced by discipline, not automation. (Historically, the x402 async migration broke ~51 tests for months precisely because nothing ran them — see the test-repair issue.)
+
+4. **Create PR to merge into `dev`**:
    - All code must go through PR review
    - CI/CD automatically deploys to staging (`provenance-gateway.dev.datafund.io`)
 
-4. **Test on staging environment** before promoting to production
+5. **Test on staging environment** before promoting to production
 
-5. **Create PR to merge `dev` into `main`**:
-   - Only after staging validation
+6. **Create PR to merge `dev` into `main`**:
+   - Only after staging validation **and** a clean local `pytest tests/` run
    - CI/CD automatically deploys to production (`provenance-gateway.datafund.io`)
 
 ### Branch Protection Rules
 
 - **Never push directly to `main`** - always use PRs
 - **Never push directly to `dev`** - always use PRs from feature branches
+- **Always run `python -m pytest tests/` locally and confirm it is green before opening or merging a PR into `dev` or `main`** - no CI runs the tests, so this is a manual gate
 - Feature branches can be pushed directly
 
 ### Deployment Environments

--- a/app/core/atomic_io.py
+++ b/app/core/atomic_io.py
@@ -1,0 +1,52 @@
+# app/core/atomic_io.py
+"""Atomic file write helpers.
+
+Writing JSON state with a plain ``open(path, 'w')`` truncates the target file
+immediately, so a crash mid-write (OOM, deploy restart, SIGKILL) leaves a
+truncated/corrupt file on disk. These helpers write to a temporary file in the
+same directory, fsync it, then atomically rename it into place. Readers always
+see either the previous complete file or the new complete file, never a partial
+one.
+
+See GitHub Issue #212.
+"""
+import json
+import os
+import tempfile
+from typing import Any
+
+__all__ = ["atomic_write_json"]
+
+
+def atomic_write_json(path: str, data: Any) -> None:
+    """Atomically write ``data`` as JSON to ``path``.
+
+    Writes to a temporary file in the same directory as the target, flushes and
+    fsyncs it, then atomically replaces the target via ``os.replace()``. Parent
+    directories are created if missing. On any failure the temporary file is
+    removed and the original target is left untouched.
+
+    Args:
+        path: Destination file path.
+        data: JSON-serializable object to persist.
+    """
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    # The temp file must live on the same filesystem as the target (i.e. in the
+    # same directory) for os.replace() to be an atomic rename rather than a
+    # cross-device copy.
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        # Never leave a partial temp file behind on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/app/services/stamp_ownership.py
+++ b/app/services/stamp_ownership.py
@@ -9,11 +9,11 @@ backward compatibility.
 """
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from threading import Lock
 from typing import Dict, Optional, Set, Tuple
 
+from app.core.atomic_io import atomic_write_json
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -39,11 +39,7 @@ class StampOwnershipManager:
         """Persist ownership registry to state file."""
         state_file = self._get_state_file_path()
         try:
-            state_dir = os.path.dirname(state_file)
-            if state_dir:
-                os.makedirs(state_dir, exist_ok=True)
-            with open(state_file, 'w') as f:
-                json.dump(self._registry, f)
+            atomic_write_json(state_file, self._registry)
             logger.debug(f"Saved ownership state: {len(self._registry)} stamps to {state_file}")
         except Exception as e:
             logger.error(f"Failed to save ownership state to {state_file}: {e}")

--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -17,13 +17,13 @@ See GitHub Issue #63 for full specification.
 import asyncio
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional, Set
 from threading import Lock
 
+from app.core.atomic_io import atomic_write_json
 from app.core.config import settings
 from app.services import swarm_api
 from app.services.stamp_ownership import stamp_ownership_manager
@@ -102,12 +102,8 @@ class StampPoolManager:
         """Persist current pool batch IDs to state file."""
         state_file = self._get_state_file_path()
         try:
-            state_dir = os.path.dirname(state_file)
-            if state_dir:
-                os.makedirs(state_dir, exist_ok=True)
             batch_ids = list(self._pool.keys())
-            with open(state_file, 'w') as f:
-                json.dump(batch_ids, f)
+            atomic_write_json(state_file, batch_ids)
             logger.debug(f"Saved pool state: {len(batch_ids)} stamps to {state_file}")
         except Exception as e:
             logger.error(f"Failed to save pool state to {state_file}: {e}")

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,88 @@
+# tests/test_atomic_io.py
+"""Tests for atomic JSON file writes (app/core/atomic_io.py).
+
+Covers GitHub Issue #212: state files must be written atomically so a crash
+mid-write cannot leave a truncated/corrupt file on disk.
+"""
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.core.atomic_io import atomic_write_json
+
+
+def _list_temp_files(directory):
+    """Return any leftover temp files created by atomic_write_json."""
+    return [name for name in os.listdir(directory) if name.startswith(".tmp-")]
+
+
+class TestAtomicWriteJson:
+    """Behaviour of atomic_write_json()."""
+
+    def test_round_trip_dict(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        data = {"a": 1, "b": [2, 3], "c": "x"}
+
+        atomic_write_json(target, data)
+
+        with open(target) as f:
+            assert json.load(f) == data
+
+    def test_round_trip_list(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, ["batch_a", "batch_b"])
+
+        with open(target) as f:
+            assert json.load(f) == ["batch_a", "batch_b"]
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = str(tmp_path / "nested" / "deeper" / "state.json")
+        atomic_write_json(target, {"ok": True})
+
+        assert os.path.exists(target)
+
+    def test_overwrites_existing_file(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"version": 1})
+        atomic_write_json(target, {"version": 2})
+
+        with open(target) as f:
+            assert json.load(f) == {"version": 2}
+
+    def test_no_temp_file_left_after_success(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"ok": True})
+
+        assert _list_temp_files(str(tmp_path)) == []
+
+    def test_existing_file_preserved_on_write_failure(self, tmp_path):
+        """If the rename fails mid-write, the original file stays intact.
+
+        This is the core crash-safety property: a failed write must never
+        truncate or corrupt the previously-persisted state.
+        """
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"version": "original"})
+
+        # Simulate a failure at the final atomic-rename step.
+        with patch("app.core.atomic_io.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                atomic_write_json(target, {"version": "new"})
+
+        # Original content must be untouched...
+        with open(target) as f:
+            assert json.load(f) == {"version": "original"}
+        # ...and no temp file should be left behind.
+        assert _list_temp_files(str(tmp_path)) == []
+
+    def test_no_temp_file_left_on_serialization_failure(self, tmp_path):
+        """A non-serializable payload raises but leaves no litter."""
+        target = str(tmp_path / "state.json")
+
+        with pytest.raises(TypeError):
+            atomic_write_json(target, {"bad": object()})
+
+        assert _list_temp_files(str(tmp_path)) == []
+        assert not os.path.exists(target)


### PR DESCRIPTION
Closes #212.

## Problem

`StampOwnershipManager` and `StampPoolManager` persisted state with a plain `open(path, 'w')`, which truncates the target file immediately. A crash mid-write (OOM, deploy restart, SIGKILL) left a truncated/corrupt JSON file. On load both managers treat a corrupt file as "start fresh" — for the **ownership registry** this silently drops wallet→stamp ownership, so a wallet loses its exclusive claim to stamps it paid for.

## Change

- New `app/core/atomic_io.py` → `atomic_write_json(path, data)`: writes to a temp file **in the same directory** (required for `os.replace()` to be an atomic rename, not a cross-device copy), `flush()` + `os.fsync()`, then `os.replace()`. Cleans up the temp file on failure; creates parent dirs.
- Wired into both `_save_state()` methods (`stamp_ownership.py`, `stamp_pool.py`), replacing the manual `makedirs` + `open`/`json.dump`. Removed the now-unused `import os` from both.

The existing `threading.Lock` already serializes concurrent in-process writes; this adds crash-safety on top. No API, schema, or config change.

## Also included

- **CLAUDE.md**: documents a mandatory development-process rule — run `python -m pytest tests/` locally and confirm green before opening or merging any PR to `dev` or `main`. There is no CI test gate (`deploy.yml` only deploys), so this is a manual gate. This came out of discovering ~51 long-broken tests (tracked separately in #215).

## Tests

- New `tests/test_atomic_io.py` (7 tests): round-trip, parent-dir creation, overwrite, no temp-file litter on success, no litter on serialization failure, and the core property — **an existing file is left intact when the write fails mid-way**.
- Full pool + ownership suites pass unchanged (81 passed).

## Notes

Single-instance hardening. The separate multi-replica shared-state concern is tracked in #213.