### PR TITLE
Promote to production: atomic state writes + async test repair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,20 +474,29 @@ feature branches → dev → main
 
 2. **Develop and test locally** on the feature branch
 
-3. **Create PR to merge into `dev`**:
+3. **Run the full test suite locally — MANDATORY before any PR to `dev` or `main`**:
+   ```bash
+   source venv/bin/activate && python -m pytest tests/ -v
+   ```
+   - There is **no CI test gate** — `deploy.yml` only deploys, it does not run pytest. The full suite passing locally is the only thing standing between a regression and staging/production.
+   - **Do not open or merge a PR to `dev` or `main` with failing or broken tests.** If a test is failing, either fix it or, if it is a known pre-existing failure, explicitly call it out in the PR description with a tracking issue — never let it pass silently.
+   - This is a **development-process rule**, enforced by discipline, not automation. (Historically, the x402 async migration broke ~51 tests for months precisely because nothing ran them — see the test-repair issue.)
+
+4. **Create PR to merge into `dev`**:
    - All code must go through PR review
    - CI/CD automatically deploys to staging (`provenance-gateway.dev.datafund.io`)
 
-4. **Test on staging environment** before promoting to production
+5. **Test on staging environment** before promoting to production
 
-5. **Create PR to merge `dev` into `main`**:
-   - Only after staging validation
+6. **Create PR to merge `dev` into `main`**:
+   - Only after staging validation **and** a clean local `pytest tests/` run
    - CI/CD automatically deploys to production (`provenance-gateway.datafund.io`)
 
 ### Branch Protection Rules
 
 - **Never push directly to `main`** - always use PRs
 - **Never push directly to `dev`** - always use PRs from feature branches
+- **Always run `python -m pytest tests/` locally and confirm it is green before opening or merging a PR into `dev` or `main`** - no CI runs the tests, so this is a manual gate
 - Feature branches can be pushed directly
 
 ### Deployment Environments

--- a/app/core/atomic_io.py
+++ b/app/core/atomic_io.py
@@ -1,0 +1,52 @@
+# app/core/atomic_io.py
+"""Atomic file write helpers.
+
+Writing JSON state with a plain ``open(path, 'w')`` truncates the target file
+immediately, so a crash mid-write (OOM, deploy restart, SIGKILL) leaves a
+truncated/corrupt file on disk. These helpers write to a temporary file in the
+same directory, fsync it, then atomically rename it into place. Readers always
+see either the previous complete file or the new complete file, never a partial
+one.
+
+See GitHub Issue #212.
+"""
+import json
+import os
+import tempfile
+from typing import Any
+
+__all__ = ["atomic_write_json"]
+
+
+def atomic_write_json(path: str, data: Any) -> None:
+    """Atomically write ``data`` as JSON to ``path``.
+
+    Writes to a temporary file in the same directory as the target, flushes and
+    fsyncs it, then atomically replaces the target via ``os.replace()``. Parent
+    directories are created if missing. On any failure the temporary file is
+    removed and the original target is left untouched.
+
+    Args:
+        path: Destination file path.
+        data: JSON-serializable object to persist.
+    """
+    directory = os.path.dirname(path) or "."
+    os.makedirs(directory, exist_ok=True)
+
+    # The temp file must live on the same filesystem as the target (i.e. in the
+    # same directory) for os.replace() to be an atomic rename rather than a
+    # cross-device copy.
+    fd, tmp_path = tempfile.mkstemp(dir=directory, prefix=".tmp-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    except Exception:
+        # Never leave a partial temp file behind on failure.
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise

--- a/app/services/stamp_ownership.py
+++ b/app/services/stamp_ownership.py
@@ -9,11 +9,11 @@ backward compatibility.
 """
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from threading import Lock
 from typing import Dict, Optional, Set, Tuple
 
+from app.core.atomic_io import atomic_write_json
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
@@ -39,11 +39,7 @@ class StampOwnershipManager:
         """Persist ownership registry to state file."""
         state_file = self._get_state_file_path()
         try:
-            state_dir = os.path.dirname(state_file)
-            if state_dir:
-                os.makedirs(state_dir, exist_ok=True)
-            with open(state_file, 'w') as f:
-                json.dump(self._registry, f)
+            atomic_write_json(state_file, self._registry)
             logger.debug(f"Saved ownership state: {len(self._registry)} stamps to {state_file}")
         except Exception as e:
             logger.error(f"Failed to save ownership state to {state_file}: {e}")

--- a/app/services/stamp_pool.py
+++ b/app/services/stamp_pool.py
@@ -17,13 +17,13 @@ See GitHub Issue #63 for full specification.
 import asyncio
 import json
 import logging
-import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Dict, List, Optional, Set
 from threading import Lock
 
+from app.core.atomic_io import atomic_write_json
 from app.core.config import settings
 from app.services import swarm_api
 from app.services.stamp_ownership import stamp_ownership_manager
@@ -102,12 +102,8 @@ class StampPoolManager:
         """Persist current pool batch IDs to state file."""
         state_file = self._get_state_file_path()
         try:
-            state_dir = os.path.dirname(state_file)
-            if state_dir:
-                os.makedirs(state_dir, exist_ok=True)
             batch_ids = list(self._pool.keys())
-            with open(state_file, 'w') as f:
-                json.dump(batch_ids, f)
+            atomic_write_json(state_file, batch_ids)
             logger.debug(f"Saved pool state: {len(batch_ids)} stamps to {state_file}")
         except Exception as e:
             logger.error(f"Failed to save pool state to {state_file}: {e}")

--- a/tests/test_atomic_io.py
+++ b/tests/test_atomic_io.py
@@ -1,0 +1,88 @@
+# tests/test_atomic_io.py
+"""Tests for atomic JSON file writes (app/core/atomic_io.py).
+
+Covers GitHub Issue #212: state files must be written atomically so a crash
+mid-write cannot leave a truncated/corrupt file on disk.
+"""
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.core.atomic_io import atomic_write_json
+
+
+def _list_temp_files(directory):
+    """Return any leftover temp files created by atomic_write_json."""
+    return [name for name in os.listdir(directory) if name.startswith(".tmp-")]
+
+
+class TestAtomicWriteJson:
+    """Behaviour of atomic_write_json()."""
+
+    def test_round_trip_dict(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        data = {"a": 1, "b": [2, 3], "c": "x"}
+
+        atomic_write_json(target, data)
+
+        with open(target) as f:
+            assert json.load(f) == data
+
+    def test_round_trip_list(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, ["batch_a", "batch_b"])
+
+        with open(target) as f:
+            assert json.load(f) == ["batch_a", "batch_b"]
+
+    def test_creates_parent_directories(self, tmp_path):
+        target = str(tmp_path / "nested" / "deeper" / "state.json")
+        atomic_write_json(target, {"ok": True})
+
+        assert os.path.exists(target)
+
+    def test_overwrites_existing_file(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"version": 1})
+        atomic_write_json(target, {"version": 2})
+
+        with open(target) as f:
+            assert json.load(f) == {"version": 2}
+
+    def test_no_temp_file_left_after_success(self, tmp_path):
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"ok": True})
+
+        assert _list_temp_files(str(tmp_path)) == []
+
+    def test_existing_file_preserved_on_write_failure(self, tmp_path):
+        """If the rename fails mid-write, the original file stays intact.
+
+        This is the core crash-safety property: a failed write must never
+        truncate or corrupt the previously-persisted state.
+        """
+        target = str(tmp_path / "state.json")
+        atomic_write_json(target, {"version": "original"})
+
+        # Simulate a failure at the final atomic-rename step.
+        with patch("app.core.atomic_io.os.replace", side_effect=OSError("boom")):
+            with pytest.raises(OSError):
+                atomic_write_json(target, {"version": "new"})
+
+        # Original content must be untouched...
+        with open(target) as f:
+            assert json.load(f) == {"version": "original"}
+        # ...and no temp file should be left behind.
+        assert _list_temp_files(str(tmp_path)) == []
+
+    def test_no_temp_file_left_on_serialization_failure(self, tmp_path):
+        """A non-serializable payload raises but leaves no litter."""
+        target = str(tmp_path / "state.json")
+
+        with pytest.raises(TypeError):
+            atomic_write_json(target, {"bad": object()})
+
+        assert _list_temp_files(str(tmp_path)) == []
+        assert not os.path.exists(target)

--- a/tests/test_base_balance.py
+++ b/tests/test_base_balance.py
@@ -3,7 +3,7 @@
 Unit tests for Base Sepolia ETH balance monitoring.
 """
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from app.x402.base_balance import (
     wei_to_eth,
@@ -49,16 +49,17 @@ class TestCheckBaseEthBalance:
         """Clear cache before each test."""
         clear_balance_cache()
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_above_threshold(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_above_threshold(self, mock_settings, mock_get_balance):
         """Balance above warning threshold returns ok=True."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)  # 0.01 ETH
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is True
         assert result["is_critical"] is False
@@ -66,16 +67,17 @@ class TestCheckBaseEthBalance:
         assert result["threshold_eth"] == 0.005
         assert result["warning"] is None
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_below_warning_threshold(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_below_warning_threshold(self, mock_settings, mock_get_balance):
         """Balance below warning threshold returns ok=False with warning."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.003 * WEI_PER_ETH)  # 0.003 ETH
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False
         assert result["is_critical"] is False
@@ -83,16 +85,17 @@ class TestCheckBaseEthBalance:
         assert "below warning threshold" in result["warning"]
         assert "Top up" in result["warning"]
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_below_critical_threshold(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_below_critical_threshold(self, mock_settings, mock_get_balance):
         """Balance below critical threshold returns is_critical=True."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.0005 * WEI_PER_ETH)  # 0.0005 ETH
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False
         assert result["is_critical"] is True
@@ -100,44 +103,47 @@ class TestCheckBaseEthBalance:
         assert "critically low" in result["warning"]
         assert "immediately" in result["warning"]
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_at_warning_threshold(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_at_warning_threshold(self, mock_settings, mock_get_balance):
         """Balance exactly at warning threshold returns ok=True."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.005 * WEI_PER_ETH)  # Exactly at threshold
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is True
         assert result["is_critical"] is False
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_at_critical_threshold(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_at_critical_threshold(self, mock_settings, mock_get_balance):
         """Balance exactly at critical threshold returns is_critical=False."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.001 * WEI_PER_ETH)  # Exactly at critical
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False  # Below warning
         assert result["is_critical"] is False  # But not below critical
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_rpc_error_returns_critical(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_rpc_error_returns_critical(self, mock_settings, mock_get_balance):
         """RPC error returns is_critical=True (can't verify balance)."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.side_effect = Exception("Connection refused")
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False
         assert result["is_critical"] is True
@@ -146,13 +152,14 @@ class TestCheckBaseEthBalance:
         assert "Connection refused" in result["warning"]
 
     @patch("app.x402.base_balance.settings")
-    def test_no_address_configured(self, mock_settings):
+    @pytest.mark.asyncio
+    async def test_no_address_configured(self, mock_settings):
         """Missing PAY_TO_ADDRESS returns error state."""
         mock_settings.X402_PAY_TO_ADDRESS = None
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False
         assert result["is_critical"] is True
@@ -160,13 +167,14 @@ class TestCheckBaseEthBalance:
         assert "not configured" in result["warning"]
 
     @patch("app.x402.base_balance.settings")
-    def test_empty_address_configured(self, mock_settings):
+    @pytest.mark.asyncio
+    async def test_empty_address_configured(self, mock_settings):
         """Empty PAY_TO_ADDRESS returns error state."""
         mock_settings.X402_PAY_TO_ADDRESS = ""
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["ok"] is False
         assert result["is_critical"] is True
@@ -179,9 +187,10 @@ class TestCaching:
         """Clear cache before each test."""
         clear_balance_cache()
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_cache_is_used(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_cache_is_used(self, mock_settings, mock_get_balance):
         """Second call uses cached value."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
@@ -189,18 +198,19 @@ class TestCaching:
         mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
 
         # First call - should fetch from RPC
-        result1 = check_base_eth_balance()
+        result1 = await check_base_eth_balance()
         # Second call - should use cache
-        result2 = check_base_eth_balance()
+        result2 = await check_base_eth_balance()
 
         # RPC should only be called once
         assert mock_get_balance.call_count == 1
         assert result1["balance_eth"] == result2["balance_eth"]
 
     @patch("app.x402.base_balance.time")
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_cache_expires(self, mock_settings, mock_get_balance, mock_time):
+    @pytest.mark.asyncio
+    async def test_cache_expires(self, mock_settings, mock_get_balance, mock_time):
         """Cache expires after TTL."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
@@ -209,25 +219,26 @@ class TestCaching:
 
         # First call at time 0
         mock_time.time.return_value = 0
-        check_base_eth_balance()
+        await check_base_eth_balance()
 
         # Second call at time 30 (within TTL)
         mock_time.time.return_value = 30
-        check_base_eth_balance()
+        await check_base_eth_balance()
 
         # Should still be just 1 RPC call
         assert mock_get_balance.call_count == 1
 
         # Third call at time 61 (after TTL)
         mock_time.time.return_value = CACHE_TTL_SECONDS + 1
-        check_base_eth_balance()
+        await check_base_eth_balance()
 
         # Should now be 2 RPC calls
         assert mock_get_balance.call_count == 2
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_clear_cache(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_clear_cache(self, mock_settings, mock_get_balance):
         """clear_balance_cache() forces new RPC call."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
@@ -235,14 +246,14 @@ class TestCaching:
         mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
 
         # First call
-        check_base_eth_balance()
+        await check_base_eth_balance()
         assert mock_get_balance.call_count == 1
 
         # Clear cache
         clear_balance_cache()
 
         # Second call - should fetch again
-        check_base_eth_balance()
+        await check_base_eth_balance()
         assert mock_get_balance.call_count == 2
 
 
@@ -253,16 +264,17 @@ class TestResponseStructure:
         """Clear cache before each test."""
         clear_balance_cache()
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_response_contains_all_fields(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_response_contains_all_fields(self, mock_settings, mock_get_balance):
         """Response contains all expected fields."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         # Check all required fields
         assert "ok" in result
@@ -274,9 +286,10 @@ class TestResponseStructure:
         assert "address" in result
         assert "warning" in result
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_response_includes_address(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_response_includes_address(self, mock_settings, mock_get_balance):
         """Response includes the monitored address."""
         address = "0xABCDEF1234567890ABCDEF1234567890ABCDEF12"
         mock_settings.X402_PAY_TO_ADDRESS = address
@@ -284,13 +297,14 @@ class TestResponseStructure:
         mock_settings.X402_BASE_ETH_CRITICAL_THRESHOLD = 0.001
         mock_get_balance.return_value = int(0.01 * WEI_PER_ETH)
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert result["address"] == address
 
-    @patch("app.x402.base_balance._get_eth_balance_from_rpc")
+    @patch("app.x402.base_balance._get_eth_balance_from_rpc", new_callable=AsyncMock)
     @patch("app.x402.base_balance.settings")
-    def test_balance_wei_is_integer(self, mock_settings, mock_get_balance):
+    @pytest.mark.asyncio
+    async def test_balance_wei_is_integer(self, mock_settings, mock_get_balance):
         """balance_wei is returned as integer."""
         mock_settings.X402_PAY_TO_ADDRESS = "0x1234567890123456789012345678901234567890"
         mock_settings.X402_BASE_ETH_WARN_THRESHOLD = 0.005
@@ -298,7 +312,7 @@ class TestResponseStructure:
         expected_wei = int(0.01 * WEI_PER_ETH)
         mock_get_balance.return_value = expected_wei
 
-        result = check_base_eth_balance()
+        result = await check_base_eth_balance()
 
         assert isinstance(result["balance_wei"], int)
         assert result["balance_wei"] == expected_wei

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -329,9 +329,14 @@ class TestMetricsBackgroundTask:
         from app.services.metrics import wallet_bzz_balance, stamps_total, _poll_balances
         import asyncio
 
+        # _poll_balances reads wallet/chequebook balances via the preflight
+        # check_* helpers, which bind get_wallet_info/get_chequebook_info at
+        # their own module level — so patch them there, not on swarm_api.
+        # get_all_stamps is imported locally inside _poll_balances, so patching
+        # it on swarm_api works.
         with patch("app.services.metrics.settings") as mock_settings, \
-             patch("app.services.swarm_api.get_wallet_info", new_callable=AsyncMock) as mock_wallet, \
-             patch("app.services.swarm_api.get_chequebook_info", new_callable=AsyncMock) as mock_cheque, \
+             patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock) as mock_wallet, \
+             patch("app.x402.preflight.get_chequebook_info", new_callable=AsyncMock) as mock_cheque, \
              patch("app.services.swarm_api.get_all_stamps", new_callable=AsyncMock) as mock_stamps:
 
             mock_settings.X402_ENABLED = False

--- a/tests/test_x402_integration.py
+++ b/tests/test_x402_integration.py
@@ -610,18 +610,20 @@ class TestHealthEndpointWithX402:
         clear_balance_cache()
 
     @patch("app.main.settings")
-    def test_health_without_x402(self, mock_settings):
+    @pytest.mark.asyncio
+    async def test_health_without_x402(self, mock_settings):
         mock_settings.X402_ENABLED = False
         mock_settings.PROJECT_NAME = "Test Gateway"
         from app.main import read_root
-        response = read_root()
+        response = await read_root()
         assert response["status"] == "ok"
         assert "x402" not in response
 
-    @patch("app.x402.preflight.check_preflight_balances")
-    @patch("app.x402.base_balance.check_base_eth_balance")
+    @patch("app.x402.preflight.check_preflight_balances", new_callable=AsyncMock)
+    @patch("app.x402.base_balance.check_base_eth_balance", new_callable=AsyncMock)
     @patch("app.main.settings")
-    def test_health_with_x402_healthy(self, mock_settings, mock_base_balance, mock_preflight):
+    @pytest.mark.asyncio
+    async def test_health_with_x402_healthy(self, mock_settings, mock_base_balance, mock_preflight):
         mock_settings.X402_ENABLED = True
         mock_settings.PROJECT_NAME = "Test Gateway"
         mock_base_balance.return_value = {
@@ -638,14 +640,15 @@ class TestHealthEndpointWithX402:
             "warnings": [], "errors": []
         }
         from app.main import read_root
-        response = read_root()
+        response = await read_root()
         assert response["status"] == "ok"
         assert response["x402"]["enabled"] is True
 
-    @patch("app.x402.preflight.check_preflight_balances")
-    @patch("app.x402.base_balance.check_base_eth_balance")
+    @patch("app.x402.preflight.check_preflight_balances", new_callable=AsyncMock)
+    @patch("app.x402.base_balance.check_base_eth_balance", new_callable=AsyncMock)
     @patch("app.main.settings")
-    def test_health_with_x402_degraded(self, mock_settings, mock_base_balance, mock_preflight):
+    @pytest.mark.asyncio
+    async def test_health_with_x402_degraded(self, mock_settings, mock_base_balance, mock_preflight):
         mock_settings.X402_ENABLED = True
         mock_settings.PROJECT_NAME = "Test Gateway"
         mock_base_balance.return_value = {
@@ -663,14 +666,15 @@ class TestHealthEndpointWithX402:
             "warnings": [], "errors": []
         }
         from app.main import read_root
-        response = read_root()
+        response = await read_root()
         assert response["status"] == "degraded"
         assert len(response["x402"]["warnings"]) == 1
 
-    @patch("app.x402.preflight.check_preflight_balances")
-    @patch("app.x402.base_balance.check_base_eth_balance")
+    @patch("app.x402.preflight.check_preflight_balances", new_callable=AsyncMock)
+    @patch("app.x402.base_balance.check_base_eth_balance", new_callable=AsyncMock)
     @patch("app.main.settings")
-    def test_health_with_x402_critical_still_returns_200(self, mock_settings, mock_base_balance, mock_preflight):
+    @pytest.mark.asyncio
+    async def test_health_with_x402_critical_still_returns_200(self, mock_settings, mock_base_balance, mock_preflight):
         mock_settings.X402_ENABLED = True
         mock_settings.PROJECT_NAME = "Test Gateway"
         mock_base_balance.return_value = {
@@ -688,14 +692,15 @@ class TestHealthEndpointWithX402:
             "warnings": [], "errors": []
         }
         from app.main import read_root
-        response = read_root()
+        response = await read_root()
         assert response["status"] == "critical"
         assert len(response["x402"]["errors"]) == 1
 
-    @patch("app.x402.preflight.check_preflight_balances")
-    @patch("app.x402.base_balance.check_base_eth_balance")
+    @patch("app.x402.preflight.check_preflight_balances", new_callable=AsyncMock)
+    @patch("app.x402.base_balance.check_base_eth_balance", new_callable=AsyncMock)
     @patch("app.main.settings")
-    def test_health_includes_wallet_addresses(self, mock_settings, mock_base_balance, mock_preflight):
+    @pytest.mark.asyncio
+    async def test_health_includes_wallet_addresses(self, mock_settings, mock_base_balance, mock_preflight):
         mock_settings.X402_ENABLED = True
         mock_settings.PROJECT_NAME = "Test Gateway"
         test_address = "0x1234567890abcdef1234567890abcdef12345678"
@@ -713,7 +718,7 @@ class TestHealthEndpointWithX402:
             "warnings": [], "errors": []
         }
         from app.main import read_root
-        response = read_root()
+        response = await read_root()
         assert response["x402"]["base_wallet"]["address"] == test_address
 
 

--- a/tests/test_x402_preflight.py
+++ b/tests/test_x402_preflight.py
@@ -3,7 +3,7 @@
 Unit tests for x402 pre-flight balance checks.
 """
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from app.x402.preflight import (
     plur_to_bzz,
@@ -48,9 +48,10 @@ class TestConversionFunctions:
 class TestCheckXBZZBalance:
     """Test xBZZ balance checks."""
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xbzz_above_threshold(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xbzz_above_threshold(self, mock_settings, mock_get_wallet):
         """xBZZ balance above threshold returns ok=True."""
         mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
         mock_get_wallet.return_value = {
@@ -58,16 +59,17 @@ class TestCheckXBZZBalance:
             "bzzBalance": str(20 * PLUR_PER_BZZ)  # 20 BZZ
         }
 
-        result = check_xbzz_balance()
+        result = await check_xbzz_balance()
 
         assert result["ok"] is True
         assert result["balance_bzz"] == 20.0
         assert result["threshold_bzz"] == 10.0
         assert result["warning"] is None
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xbzz_below_threshold(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xbzz_below_threshold(self, mock_settings, mock_get_wallet):
         """xBZZ balance below threshold returns ok=False with warning."""
         mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
         mock_get_wallet.return_value = {
@@ -75,16 +77,17 @@ class TestCheckXBZZBalance:
             "bzzBalance": str(5 * PLUR_PER_BZZ)  # 5 BZZ
         }
 
-        result = check_xbzz_balance()
+        result = await check_xbzz_balance()
 
         assert result["ok"] is False
         assert result["balance_bzz"] == 5.0
         assert result["threshold_bzz"] == 10.0
         assert "below threshold" in result["warning"]
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xbzz_at_exact_threshold(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xbzz_at_exact_threshold(self, mock_settings, mock_get_wallet):
         """xBZZ balance exactly at threshold returns ok=True."""
         mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
         mock_get_wallet.return_value = {
@@ -92,19 +95,20 @@ class TestCheckXBZZBalance:
             "bzzBalance": str(10 * PLUR_PER_BZZ)  # 10 BZZ
         }
 
-        result = check_xbzz_balance()
+        result = await check_xbzz_balance()
 
         assert result["ok"] is True
         assert result["balance_bzz"] == 10.0
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xbzz_api_error(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xbzz_api_error(self, mock_settings, mock_get_wallet):
         """API error returns ok=False with error message."""
         mock_settings.X402_XBZZ_WARN_THRESHOLD = 10.0
         mock_get_wallet.side_effect = Exception("Connection refused")
 
-        result = check_xbzz_balance()
+        result = await check_xbzz_balance()
 
         assert result["ok"] is False
         assert result["balance_bzz"] == 0.0
@@ -114,9 +118,10 @@ class TestCheckXBZZBalance:
 class TestCheckXDAIBalance:
     """Test xDAI balance checks."""
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xdai_above_threshold(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xdai_above_threshold(self, mock_settings, mock_get_wallet):
         """xDAI balance above threshold returns ok=True."""
         mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
         mock_get_wallet.return_value = {
@@ -124,16 +129,17 @@ class TestCheckXDAIBalance:
             "nativeTokenBalance": str(int(1.0 * WEI_PER_XDAI))  # 1 xDAI
         }
 
-        result = check_xdai_balance()
+        result = await check_xdai_balance()
 
         assert result["ok"] is True
         assert result["balance_xdai"] == 1.0
         assert result["threshold_xdai"] == 0.5
         assert result["warning"] is None
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xdai_below_threshold(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xdai_below_threshold(self, mock_settings, mock_get_wallet):
         """xDAI balance below threshold returns ok=False with warning."""
         mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
         mock_get_wallet.return_value = {
@@ -141,16 +147,17 @@ class TestCheckXDAIBalance:
             "nativeTokenBalance": str(int(0.1 * WEI_PER_XDAI))  # 0.1 xDAI
         }
 
-        result = check_xdai_balance()
+        result = await check_xdai_balance()
 
         assert result["ok"] is False
         assert result["balance_xdai"] == 0.1
         assert "below threshold" in result["warning"]
         assert "gas" in result["warning"].lower()
 
-    @patch("app.x402.preflight.get_wallet_info")
+    @patch("app.x402.preflight.get_wallet_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_xdai_missing_field(self, mock_settings, mock_get_wallet):
+    @pytest.mark.asyncio
+    async def test_xdai_missing_field(self, mock_settings, mock_get_wallet):
         """Missing nativeTokenBalance field defaults to 0."""
         mock_settings.X402_XDAI_WARN_THRESHOLD = 0.5
         mock_get_wallet.return_value = {
@@ -158,7 +165,7 @@ class TestCheckXDAIBalance:
             # nativeTokenBalance missing
         }
 
-        result = check_xdai_balance()
+        result = await check_xdai_balance()
 
         assert result["ok"] is False
         assert result["balance_xdai"] == 0.0
@@ -167,9 +174,10 @@ class TestCheckXDAIBalance:
 class TestCheckChequebookBalance:
     """Test chequebook balance checks."""
 
-    @patch("app.x402.preflight.get_chequebook_info")
+    @patch("app.x402.preflight.get_chequebook_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_chequebook_above_threshold(self, mock_settings, mock_get_chequebook):
+    @pytest.mark.asyncio
+    async def test_chequebook_above_threshold(self, mock_settings, mock_get_chequebook):
         """Chequebook balance above threshold returns ok=True."""
         mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
         mock_get_chequebook.return_value = {
@@ -178,7 +186,7 @@ class TestCheckChequebookBalance:
             "totalBalance": str(15 * PLUR_PER_BZZ)  # 15 BZZ
         }
 
-        result = check_chequebook_balance()
+        result = await check_chequebook_balance()
 
         assert result["ok"] is True
         assert result["available_balance_bzz"] == 10.0
@@ -186,9 +194,10 @@ class TestCheckChequebookBalance:
         assert result["threshold_bzz"] == 5.0
         assert result["warning"] is None
 
-    @patch("app.x402.preflight.get_chequebook_info")
+    @patch("app.x402.preflight.get_chequebook_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_chequebook_below_threshold(self, mock_settings, mock_get_chequebook):
+    @pytest.mark.asyncio
+    async def test_chequebook_below_threshold(self, mock_settings, mock_get_chequebook):
         """Chequebook balance below threshold returns ok=False with warning."""
         mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
         mock_get_chequebook.return_value = {
@@ -197,23 +206,24 @@ class TestCheckChequebookBalance:
             "totalBalance": str(5 * PLUR_PER_BZZ)  # 5 BZZ
         }
 
-        result = check_chequebook_balance()
+        result = await check_chequebook_balance()
 
         assert result["ok"] is False
         assert result["available_balance_bzz"] == 2.0
         assert "below threshold" in result["warning"]
         assert "bandwidth" in result["warning"].lower()
 
-    @patch("app.x402.preflight.get_chequebook_balance")
-    @patch("app.x402.preflight.get_chequebook_info")
+    @patch("app.x402.preflight.get_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.get_chequebook_info", new_callable=AsyncMock)
     @patch("app.x402.preflight.settings")
-    def test_chequebook_api_error(self, mock_settings, mock_get_chequebook_info, mock_get_chequebook_balance):
+    @pytest.mark.asyncio
+    async def test_chequebook_api_error(self, mock_settings, mock_get_chequebook_info, mock_get_chequebook_balance):
         """API error returns ok=False with error message."""
         mock_settings.X402_CHEQUEBOOK_WARN_THRESHOLD = 5.0
         mock_get_chequebook_info.side_effect = Exception("Connection refused")
         mock_get_chequebook_balance.side_effect = Exception("Connection refused")
 
-        result = check_chequebook_balance()
+        result = await check_chequebook_balance()
 
         assert result["ok"] is False
         assert result["available_balance_bzz"] == 0.0
@@ -223,10 +233,11 @@ class TestCheckChequebookBalance:
 class TestCheckPreflightBalances:
     """Test combined pre-flight balance checks."""
 
-    @patch("app.x402.preflight.check_chequebook_balance")
-    @patch("app.x402.preflight.check_xdai_balance")
-    @patch("app.x402.preflight.check_xbzz_balance")
-    def test_all_checks_pass(self, mock_xbzz, mock_xdai, mock_chequebook):
+    @patch("app.x402.preflight.check_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xdai_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xbzz_balance", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_all_checks_pass(self, mock_xbzz, mock_xdai, mock_chequebook):
         """All checks passing returns can_accept=True."""
         mock_xbzz.return_value = {
             "ok": True,
@@ -255,7 +266,7 @@ class TestCheckPreflightBalances:
             "warning": None
         }
 
-        result = check_preflight_balances()
+        result = await check_preflight_balances()
 
         assert result["can_accept"] is True
         assert result["xbzz_ok"] is True
@@ -264,10 +275,11 @@ class TestCheckPreflightBalances:
         assert len(result["warnings"]) == 0
         assert len(result["errors"]) == 0
 
-    @patch("app.x402.preflight.check_chequebook_balance")
-    @patch("app.x402.preflight.check_xdai_balance")
-    @patch("app.x402.preflight.check_xbzz_balance")
-    def test_low_balance_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
+    @patch("app.x402.preflight.check_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xdai_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xbzz_balance", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_low_balance_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
         """Low balances generate warnings but can still accept."""
         mock_xbzz.return_value = {
             "ok": False,
@@ -296,7 +308,7 @@ class TestCheckPreflightBalances:
             "warning": None
         }
 
-        result = check_preflight_balances()
+        result = await check_preflight_balances()
 
         # Can accept even with low balance (warning only)
         assert result["can_accept"] is True
@@ -304,10 +316,11 @@ class TestCheckPreflightBalances:
         assert len(result["warnings"]) == 1
         assert len(result["errors"]) == 0
 
-    @patch("app.x402.preflight.check_chequebook_balance")
-    @patch("app.x402.preflight.check_xdai_balance")
-    @patch("app.x402.preflight.check_xbzz_balance")
-    def test_api_error_generates_warning_not_error(self, mock_xbzz, mock_xdai, mock_chequebook):
+    @patch("app.x402.preflight.check_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xdai_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xbzz_balance", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_api_error_generates_warning_not_error(self, mock_xbzz, mock_xdai, mock_chequebook):
         """Bee node connectivity issues are warnings, not blocking errors."""
         mock_xbzz.return_value = {
             "ok": False,
@@ -336,7 +349,7 @@ class TestCheckPreflightBalances:
             "warning": None
         }
 
-        result = check_preflight_balances()
+        result = await check_preflight_balances()
 
         # Gateway stays available; Bee node issues are warnings not errors
         assert result["can_accept"] is True
@@ -345,10 +358,11 @@ class TestCheckPreflightBalances:
         unreachable_warnings = [w for w in result["warnings"] if "unreachable" in w.lower()]
         assert len(unreachable_warnings) == 1
 
-    @patch("app.x402.preflight.check_chequebook_balance")
-    @patch("app.x402.preflight.check_xdai_balance")
-    @patch("app.x402.preflight.check_xbzz_balance")
-    def test_balances_structure(self, mock_xbzz, mock_xdai, mock_chequebook):
+    @patch("app.x402.preflight.check_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xdai_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xbzz_balance", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_balances_structure(self, mock_xbzz, mock_xdai, mock_chequebook):
         """Verify balances structure in response."""
         mock_xbzz.return_value = {
             "ok": True,
@@ -377,7 +391,7 @@ class TestCheckPreflightBalances:
             "warning": None
         }
 
-        result = check_preflight_balances()
+        result = await check_preflight_balances()
 
         # Verify balances structure
         assert "balances" in result
@@ -395,10 +409,11 @@ class TestCheckPreflightBalances:
         assert result["balances"]["chequebook"]["total_bzz"] == 15.0
         assert result["balances"]["chequebook"]["threshold_bzz"] == 5.0
 
-    @patch("app.x402.preflight.check_chequebook_balance")
-    @patch("app.x402.preflight.check_xdai_balance")
-    @patch("app.x402.preflight.check_xbzz_balance")
-    def test_multiple_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
+    @patch("app.x402.preflight.check_chequebook_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xdai_balance", new_callable=AsyncMock)
+    @patch("app.x402.preflight.check_xbzz_balance", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_multiple_warnings(self, mock_xbzz, mock_xdai, mock_chequebook):
         """Multiple low balances generate multiple warnings."""
         mock_xbzz.return_value = {
             "ok": False,
@@ -427,7 +442,7 @@ class TestCheckPreflightBalances:
             "warning": "Chequebook below threshold"
         }
 
-        result = check_preflight_balances()
+        result = await check_preflight_balances()
 
         # Can still accept (low balance = warning, not error)
         assert result["can_accept"] is True

--- a/tests/test_x402_pricing.py
+++ b/tests/test_x402_pricing.py
@@ -3,7 +3,7 @@
 Unit tests for x402 pricing service.
 """
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from app.x402.pricing import (
     plur_to_bzz,
@@ -73,8 +73,9 @@ class TestCalculateStampPriceUSD:
     """Test stamp price calculations."""
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_basic_stamp_price(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_basic_stamp_price(self, mock_chainstate, mock_settings):
         """Calculate basic stamp price."""
         # Configure mocks
         mock_settings.X402_BZZ_USD_RATE = 0.50
@@ -84,7 +85,7 @@ class TestCalculateStampPriceUSD:
         # Current price of 1000 PLUR per chunk per block
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = calculate_stamp_price_usd(
+        result = await calculate_stamp_price_usd(
             duration_hours=24,
             depth=17,
             include_breakdown=True
@@ -104,8 +105,9 @@ class TestCalculateStampPriceUSD:
         assert result["markup_percent"] == 50.0
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_minimum_price_applied(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_minimum_price_applied(self, mock_chainstate, mock_settings):
         """Verify minimum price is applied for small requests."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 0.0
@@ -114,7 +116,7 @@ class TestCalculateStampPriceUSD:
         # Very low price to trigger minimum
         mock_chainstate.return_value = {"currentPrice": "1"}
 
-        result = calculate_stamp_price_usd(
+        result = await calculate_stamp_price_usd(
             duration_hours=1,
             depth=17,
             include_breakdown=True
@@ -124,8 +126,9 @@ class TestCalculateStampPriceUSD:
         assert result["minimum_applied"] is True
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_markup_applied(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_markup_applied(self, mock_chainstate, mock_settings):
         """Verify markup is correctly applied."""
         mock_settings.X402_BZZ_USD_RATE = 1.00  # 1:1 for easy calculation
         mock_settings.X402_MARKUP_PERCENT = 100.0  # Double the price
@@ -133,7 +136,7 @@ class TestCalculateStampPriceUSD:
 
         mock_chainstate.return_value = {"currentPrice": "1000000"}
 
-        result = calculate_stamp_price_usd(
+        result = await calculate_stamp_price_usd(
             duration_hours=24,
             depth=17,
             include_breakdown=True
@@ -146,17 +149,19 @@ class TestCalculateStampPriceUSD:
         # Allow for rounding
         assert abs(final_price - base_cost * 2) < 0.01
 
-    @patch("app.x402.pricing.get_chainstate")
-    def test_invalid_chainstate_price(self, mock_chainstate):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_invalid_chainstate_price(self, mock_chainstate):
         """Raise error for invalid chainstate price."""
         mock_chainstate.return_value = {"currentPrice": "0"}
 
         with pytest.raises(ValueError, match="Invalid current price"):
-            calculate_stamp_price_usd(duration_hours=24, depth=17)
+            await calculate_stamp_price_usd(duration_hours=24, depth=17)
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_breakdown_structure(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_breakdown_structure(self, mock_chainstate, mock_settings):
         """Verify breakdown contains all expected fields."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -164,7 +169,7 @@ class TestCalculateStampPriceUSD:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = calculate_stamp_price_usd(
+        result = await calculate_stamp_price_usd(
             duration_hours=24,
             depth=17,
             include_breakdown=True
@@ -183,8 +188,9 @@ class TestCalculateStampPriceUSD:
         assert "final_price_usd" in breakdown
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_no_breakdown_option(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_no_breakdown_option(self, mock_chainstate, mock_settings):
         """Verify breakdown can be excluded."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -192,7 +198,7 @@ class TestCalculateStampPriceUSD:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = calculate_stamp_price_usd(
+        result = await calculate_stamp_price_usd(
             duration_hours=24,
             depth=17,
             include_breakdown=False
@@ -205,8 +211,9 @@ class TestCalculateUploadPriceUSD:
     """Test upload price calculations."""
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_small_upload(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_small_upload(self, mock_chainstate, mock_settings):
         """Calculate price for small upload (fits in minimum depth)."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -215,7 +222,7 @@ class TestCalculateUploadPriceUSD:
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
         # 1 KB upload
-        result = calculate_upload_price_usd(
+        result = await calculate_upload_price_usd(
             size_bytes=1024,
             duration_hours=24,
             include_breakdown=True
@@ -226,8 +233,9 @@ class TestCalculateUploadPriceUSD:
         assert result["breakdown"]["depth_used"] == 17  # Minimum depth
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_large_upload_increases_depth(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_large_upload_increases_depth(self, mock_chainstate, mock_settings):
         """Large uploads should use higher depth."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -236,7 +244,7 @@ class TestCalculateUploadPriceUSD:
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
         # 1 GB upload - should need depth > 17
-        result = calculate_upload_price_usd(
+        result = await calculate_upload_price_usd(
             size_bytes=1024 * 1024 * 1024,  # 1 GB
             duration_hours=24,
             include_breakdown=True
@@ -246,8 +254,9 @@ class TestCalculateUploadPriceUSD:
         assert result["breakdown"]["depth_used"] > 17
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_upload_breakdown_structure(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_upload_breakdown_structure(self, mock_chainstate, mock_settings):
         """Verify upload breakdown contains expected fields."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -255,7 +264,7 @@ class TestCalculateUploadPriceUSD:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = calculate_upload_price_usd(
+        result = await calculate_upload_price_usd(
             size_bytes=1024,
             duration_hours=24,
             include_breakdown=True
@@ -274,8 +283,9 @@ class TestGetPriceQuote:
     """Test price quote generation."""
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_stamp_purchase_quote(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_stamp_purchase_quote(self, mock_chainstate, mock_settings):
         """Generate quote for stamp purchase."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -285,7 +295,7 @@ class TestGetPriceQuote:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = get_price_quote(
+        result = await get_price_quote(
             operation="stamp_purchase",
             duration_hours=24,
             depth=17
@@ -298,8 +308,9 @@ class TestGetPriceQuote:
         assert "details" in result
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_upload_quote(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_upload_quote(self, mock_chainstate, mock_settings):
         """Generate quote for upload."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -309,7 +320,7 @@ class TestGetPriceQuote:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = get_price_quote(
+        result = await get_price_quote(
             operation="upload",
             size_bytes=1024,
             duration_hours=24
@@ -320,8 +331,9 @@ class TestGetPriceQuote:
         assert result["network"] == "base-sepolia"
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_missing_pay_to_address(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_missing_pay_to_address(self, mock_chainstate, mock_settings):
         """Handle missing pay_to address gracefully."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -331,7 +343,7 @@ class TestGetPriceQuote:
 
         mock_chainstate.return_value = {"currentPrice": "1000"}
 
-        result = get_price_quote(
+        result = await get_price_quote(
             operation="stamp_purchase",
             duration_hours=24
         )
@@ -339,18 +351,20 @@ class TestGetPriceQuote:
         # Should use placeholder address
         assert result["pay_to"] == "0x0000000000000000000000000000000000000000"
 
-    def test_unknown_operation(self):
+    @pytest.mark.asyncio
+    async def test_unknown_operation(self):
         """Raise error for unknown operation type."""
         with pytest.raises(ValueError, match="Unknown operation type"):
-            get_price_quote(operation="unknown_operation")
+            await get_price_quote(operation="unknown_operation")
 
 
 class TestPricingFormulas:
     """Test the pricing formula calculations."""
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_price_increases_with_duration(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_price_increases_with_duration(self, mock_chainstate, mock_settings):
         """Longer duration should increase price."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -358,14 +372,15 @@ class TestPricingFormulas:
 
         mock_chainstate.return_value = {"currentPrice": "1000000"}
 
-        price_24h = calculate_stamp_price_usd(duration_hours=24, depth=17)
-        price_48h = calculate_stamp_price_usd(duration_hours=48, depth=17)
+        price_24h = await calculate_stamp_price_usd(duration_hours=24, depth=17)
+        price_48h = await calculate_stamp_price_usd(duration_hours=48, depth=17)
 
         assert price_48h["price_usd"] > price_24h["price_usd"]
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_price_increases_with_depth(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_price_increases_with_depth(self, mock_chainstate, mock_settings):
         """Higher depth (more storage) should increase price."""
         mock_settings.X402_BZZ_USD_RATE = 0.50
         mock_settings.X402_MARKUP_PERCENT = 50.0
@@ -373,15 +388,16 @@ class TestPricingFormulas:
 
         mock_chainstate.return_value = {"currentPrice": "1000000"}
 
-        price_d17 = calculate_stamp_price_usd(duration_hours=24, depth=17)
-        price_d20 = calculate_stamp_price_usd(duration_hours=24, depth=20)
+        price_d17 = await calculate_stamp_price_usd(duration_hours=24, depth=17)
+        price_d20 = await calculate_stamp_price_usd(duration_hours=24, depth=20)
 
         # depth 20 has 8x the capacity of depth 17, so should cost more
         assert price_d20["price_usd"] > price_d17["price_usd"]
 
     @patch("app.x402.pricing.settings")
-    @patch("app.x402.pricing.get_chainstate")
-    def test_price_scales_with_exchange_rate(self, mock_chainstate, mock_settings):
+    @patch("app.x402.pricing.get_chainstate", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_price_scales_with_exchange_rate(self, mock_chainstate, mock_settings):
         """Higher exchange rate should increase USD price."""
         mock_settings.X402_MARKUP_PERCENT = 0.0
         mock_settings.X402_MIN_PRICE_USD = 0.0
@@ -390,11 +406,11 @@ class TestPricingFormulas:
 
         # Price at $0.50/BZZ
         mock_settings.X402_BZZ_USD_RATE = 0.50
-        price_low = calculate_stamp_price_usd(duration_hours=24, depth=17)
+        price_low = await calculate_stamp_price_usd(duration_hours=24, depth=17)
 
         # Price at $1.00/BZZ (2x rate)
         mock_settings.X402_BZZ_USD_RATE = 1.00
-        price_high = calculate_stamp_price_usd(duration_hours=24, depth=17)
+        price_high = await calculate_stamp_price_usd(duration_hours=24, depth=17)
 
         # Price should approximately double
         ratio = price_high["price_usd"] / price_low["price_usd"]


### PR DESCRIPTION
Promotes `dev` → `main`. Validated on staging (provenance-gateway.dev.datafund.io) and full local suite green (844 passed, 7 skipped).

Contains exactly today's two merged PRs:

- **#214** — Write JSON state files atomically (ownership registry, stamp pool) to prevent corruption on crash. Also adds the CLAUDE.md rule requiring a clean local `pytest tests/` before merging to `dev`/`main`. Closes #212.
- **#216** — Repair 51 stale tests broken by the x402 async migration (async/await + AsyncMock patch targets). Tests-only; no production code change. Closes #215.

Staging smoke tests after these merges: `/health`, `/api/v1/pool/status`, `/api/v1/stamps/`, `/api/v1/notary/status`, `/metrics` all 200 and healthy.