### PR TITLE
Add signature-gated read-only Bee diagnostics proxy (/api/v1/debug/bee)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,13 @@ SWARM_BEE_API_URL=https://api.gateway.ethswarm.org
 # X402_BANDWIDTH_USD_PER_GB=0.10                 # Price per GB used to convert top-ups to credit
 # BANDWIDTH_CREDIT_MIN_TOPUP_MB=100             # Minimum top-up so one payment clears the price floor
 
+# === Debug proxy (read-only Bee diagnostics, signature-gated) ===
+# Comma-separated 0x addresses allowed to read Bee diagnostics via
+# GET /api/v1/debug/bee/{path}. Empty => endpoint disabled (404). Addresses are
+# public (not secrets); access requires an EIP-191 signature from one of them.
+# DEBUG_ALLOWED_ADDRESSES=
+# DEBUG_SIG_MAX_AGE_SECONDS=300
+
 # === JSON Body Limits ===
 # Protects against denial-of-service via deeply nested or oversized JSON payloads.
 # MAX_JSON_BODY_BYTES=1048576                    # Max JSON body size in bytes (default: 1 MB)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,8 @@ jobs:
           X402_BANDWIDTH_USD_PER_GB=${{ vars.X402_BANDWIDTH_USD_PER_GB || '0.10' }}
           BANDWIDTH_CREDIT_MIN_TOPUP_MB=${{ vars.BANDWIDTH_CREDIT_MIN_TOPUP_MB || '100' }}
           BANDWIDTH_CREDIT_STATE_FILE=${{ vars.BANDWIDTH_CREDIT_STATE_FILE || 'data/bandwidth_credit.json' }}
+          DEBUG_ALLOWED_ADDRESSES=${{ vars.DEBUG_ALLOWED_ADDRESSES || '' }}
+          DEBUG_SIG_MAX_AGE_SECONDS=${{ vars.DEBUG_SIG_MAX_AGE_SECONDS || '300' }}
           RATE_LIMIT_ENABLED=${{ vars.RATE_LIMIT_ENABLED || 'true' }}
           RATE_LIMIT_PER_MINUTE=${{ vars.RATE_LIMIT_PER_MINUTE || '60' }}
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}
@@ -107,6 +109,8 @@ jobs:
           X402_BANDWIDTH_USD_PER_GB=${{ vars.X402_BANDWIDTH_USD_PER_GB || '0.10' }}
           BANDWIDTH_CREDIT_MIN_TOPUP_MB=${{ vars.BANDWIDTH_CREDIT_MIN_TOPUP_MB || '100' }}
           BANDWIDTH_CREDIT_STATE_FILE=${{ vars.BANDWIDTH_CREDIT_STATE_FILE || 'data/bandwidth_credit.json' }}
+          DEBUG_ALLOWED_ADDRESSES=${{ vars.DEBUG_ALLOWED_ADDRESSES || '' }}
+          DEBUG_SIG_MAX_AGE_SECONDS=${{ vars.DEBUG_SIG_MAX_AGE_SECONDS || '300' }}
           RATE_LIMIT_ENABLED=${{ vars.RATE_LIMIT_ENABLED || 'true' }}
           RATE_LIMIT_PER_MINUTE=${{ vars.RATE_LIMIT_PER_MINUTE || '60' }}
           RATE_LIMIT_BURST=${{ vars.RATE_LIMIT_BURST || '10' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,6 +154,9 @@ CORS (browser access):
 - `GET /api/v1/data/{reference}`: Download raw data from Swarm (returns bytes directly)
 - `GET /api/v1/data/{reference}/json`: Download data with JSON metadata (base64-encoded)
 
+#### Debug (read-only Bee diagnostics, signature-gated)
+- `GET /api/v1/debug/bee/{path}`: read-only proxy to allow-listed Bee endpoints (`topology`, `addresses`, `peers`, `status`, `chainstate`, `reservestate`, `redistributionstate`, `node`, `health`, `readiness`, `stamps`, `batches`, `chequebook`, `wallet`) for diagnosing the gateway's Bee node when you only have gateway access. Disabled (404) unless `DEBUG_ALLOWED_ADDRESSES` (comma-separated 0x addresses) is set. Auth = EIP-191 signature from an allow-listed address over `swarm-connect-debug:<unix_ts>` via headers `X-Debug-Timestamp` + `X-Debug-Signature` (freshness window `DEBUG_SIG_MAX_AGE_SECONDS`, default 300s). No stored secret; never proxies writes.
+
 #### Chunk Forwarding (pre-stamped, Flow A)
 - `POST /api/v1/chunks/`: Forward a single **client-supplied pre-stamped** chunk to Bee `POST /chunks`. Raw chunk in the body, marshaled stamp in the `Swarm-Postage-Stamp` header (sent instead of `Swarm-Postage-Batch-Id`); optional `?deferred=true` (default false). The client owns the postage batch and signs locally; the gateway is a thin forwarder and does **not** verify the stamp (Bee does). Always mounted; the handler returns 404 when `CHUNK_UPLOAD_ENABLED=false`.
 - `POST /api/v1/chunks/credit?mb={n}`: x402-paid prepaid **bandwidth credit** top-up. Priced via the `bandwidth` operation in `pricing.py` at `X402_BANDWIDTH_USD_PER_GB` (min `BANDWIDTH_CREDIT_MIN_TOPUP_MB`). Credit is bound to the verified x402 payer wallet; returns a bearer token.

--- a/README.md
+++ b/README.md
@@ -280,6 +280,9 @@ Swarm Connect is a FastAPI-based API gateway that provides comprehensive access 
 - `GET /api/v1/data/{reference}`: Download raw data from Swarm (returns bytes directly)
 - `GET /api/v1/data/{reference}/json`: Download data with JSON metadata (base64-encoded)
 
+#### Debug (read-only Bee diagnostics)
+- `GET /api/v1/debug/bee/{path}`: signature-gated read-only proxy to allow-listed Bee diagnostic endpoints (`topology`, `addresses`, `peers`, `status`, `chainstate`, …) for operators who only have gateway access. Disabled (404) unless `DEBUG_ALLOWED_ADDRESSES` is set; requires an EIP-191 signature from an allow-listed address (`X-Debug-Timestamp` + `X-Debug-Signature` over `swarm-connect-debug:<unix_ts>`). No shared secret is stored.
+
 #### Chunk Forwarding (pre-stamped)
 - `POST /api/v1/chunks/`: Forward a single **client-supplied pre-stamped** chunk to Swarm. Send the raw chunk as the body and the marshaled stamp in the `Swarm-Postage-Stamp` header. The client owns the postage batch and stamps locally; the gateway is a thin forwarder (does not verify the stamp — Bee does). Optional `?deferred=true`. Requires `CHUNK_UPLOAD_ENABLED=true` (returns 404 when disabled). When x402 is enabled, the upload spends prepaid bandwidth credit: present the bearer token from the top-up in the `X-Bandwidth-Credit-Token` header (the chunk's byte length is debited). A **free tier** is also available — send `X-Payment-Mode: free` to draw from a per-IP daily byte quota (`CHUNK_UPLOAD_FREE_TIER_MB_PER_DAY`); exceeding it returns `429`.
 - `POST /api/v1/chunks/credit?mb={n}`: Add prepaid bandwidth credit with a single x402 payment (priced at `X402_BANDWIDTH_USD_PER_GB`, minimum `BANDWIDTH_CREDIT_MIN_TOPUP_MB`). Returns a bearer **credit token** bound to the payer wallet; reuse it across many chunk uploads so per-chunk requests never hit the minimum-price floor.

--- a/app/api/endpoints/debug.py
+++ b/app/api/endpoints/debug.py
@@ -1,0 +1,118 @@
+# app/api/endpoints/debug.py
+"""
+Signature-gated, read-only proxy for Bee diagnostic endpoints.
+
+Operators who only have access to the gateway (not the Bee node's API) can read
+the node's diagnostics (topology, peers, status, ...) by proving control of an
+allow-listed address — no shared secret is stored anywhere.
+
+Auth: send an EIP-191 personal_sign of "swarm-connect-debug:<unix_ts>" by an
+allow-listed address.
+  Headers: X-Debug-Timestamp: <unix seconds>
+           X-Debug-Signature: 0x<65-byte sig>
+The signer is recovered and must be in DEBUG_ALLOWED_ADDRESSES; the timestamp
+must be within DEBUG_SIG_MAX_AGE_SECONDS (replay guard).
+
+Disabled (404) when DEBUG_ALLOWED_ADDRESSES is empty. Only read-only, allow-listed
+Bee paths are proxied — never writes.
+"""
+import logging
+import time
+from typing import Optional
+from urllib.parse import urljoin
+
+import httpx
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from fastapi.responses import Response
+
+from app.core.config import settings
+from app.services.http_client import get_client
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+# Read-only Bee endpoints safe to expose for diagnostics (matched on first path segment).
+ALLOWED_BEE_PATHS = {
+    "topology", "addresses", "health", "readiness", "peers", "chainstate",
+    "reservestate", "redistributionstate", "status", "node", "stamps",
+    "batches", "chequebook", "wallet",
+}
+
+SIG_MESSAGE_PREFIX = "swarm-connect-debug:"
+
+
+def _authorize(timestamp: Optional[str], signature: Optional[str]) -> str:
+    """Verify the request is signed by an allow-listed address over a fresh timestamp.
+
+    Returns the recovered address, or raises HTTPException.
+    """
+    allowed = settings.get_debug_allowed_addresses()
+    if not allowed:
+        # Hidden when not configured.
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
+
+    if not timestamp or not signature:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing X-Debug-Timestamp / X-Debug-Signature",
+        )
+
+    try:
+        ts = int(timestamp)
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid timestamp")
+
+    if abs(int(time.time()) - ts) > settings.DEBUG_SIG_MAX_AGE_SECONDS:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Stale or future timestamp")
+
+    message = encode_defunct(text=f"{SIG_MESSAGE_PREFIX}{ts}")
+    try:
+        signer = Account.recover_message(message, signature=signature)
+    except Exception:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature")
+
+    if signer.lower() not in allowed:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Address not allow-listed")
+    return signer
+
+
+@router.get("/bee/{bee_path:path}", summary="Read-only proxy to allow-listed Bee diagnostic endpoints")
+async def debug_bee(
+    bee_path: str,
+    request: Request,
+    x_debug_timestamp: Optional[str] = Header(default=None, alias="X-Debug-Timestamp"),
+    x_debug_signature: Optional[str] = Header(default=None, alias="X-Debug-Signature"),
+) -> Response:
+    """Proxy a GET to the gateway's Bee node for an allow-listed diagnostic path.
+
+    Example: `GET /api/v1/debug/bee/topology`. Requires a valid signature from an
+    address in `DEBUG_ALLOWED_ADDRESSES`.
+    """
+    _authorize(x_debug_timestamp, x_debug_signature)
+
+    top = bee_path.strip("/").split("/")[0]
+    if top not in ALLOWED_BEE_PATHS:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={"code": "PATH_NOT_ALLOWED", "message": f"'{top}' is not a permitted debug path",
+                    "allowed": sorted(ALLOWED_BEE_PATHS)},
+        )
+
+    url = urljoin(str(settings.SWARM_BEE_API_URL), bee_path.lstrip("/"))
+    if request.url.query:
+        url = f"{url}?{request.url.query}"
+
+    try:
+        client = get_client()
+        resp = await client.get(url, timeout=15)
+    except httpx.HTTPError as e:
+        logger.warning(f"debug proxy: Bee request failed ({url}): {e}")
+        raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail="Bee node request failed")
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        media_type=resp.headers.get("content-type", "application/json"),
+    )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -86,6 +86,15 @@ class Settings(BaseSettings):
     # Stamp ownership: file path for persisting stamp ownership records
     STAMP_OWNERSHIP_FILE: str = "data/stamp_owners.json"
 
+    # === Debug Proxy (read-only Bee diagnostics, signature-gated) ===
+    # Comma-separated 0x addresses allowed to read Bee diagnostics via
+    # GET /api/v1/debug/bee/{path}. Access requires an EIP-191 signature from one
+    # of these addresses over "swarm-connect-debug:<unix_ts>" (headers
+    # X-Debug-Address optional, X-Debug-Timestamp, X-Debug-Signature). Empty =>
+    # endpoint disabled (404). Addresses are public identifiers, not secrets.
+    DEBUG_ALLOWED_ADDRESSES: str = ""
+    DEBUG_SIG_MAX_AGE_SECONDS: int = 300  # signature freshness window (replay guard)
+
     # === Notary/Provenance Signing Settings ===
     # The notary feature allows the gateway to sign documents with an authoritative timestamp.
     # This provides proof that a document existed at a specific time, signed by the gateway.
@@ -166,6 +175,12 @@ class Settings(BaseSettings):
         if not self.X402_WHITELIST_IPS:
             return []
         return [ip.strip() for ip in self.X402_WHITELIST_IPS.split(",") if ip.strip()]
+
+    def get_debug_allowed_addresses(self) -> List[str]:
+        """Parse the debug allow-list into lowercased 0x addresses."""
+        if not self.DEBUG_ALLOWED_ADDRESSES:
+            return []
+        return [a.strip().lower() for a in self.DEBUG_ALLOWED_ADDRESSES.split(",") if a.strip()]
 
     def get_stamp_pool_reserve_config(self) -> dict:
         """Get stamp pool reserve configuration as {depth: count} dict.

--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from app.core.config import settings
 from app.core.version import VERSION
-from app.api.endpoints import stamps, data, wallet, pool, notary, chunks
+from app.api.endpoints import stamps, data, wallet, pool, notary, chunks, debug
 import logging
 
 # Configure basic logging
@@ -135,6 +135,9 @@ app.include_router(notary.router, prefix=f"{settings.API_V1_STR}/notary", tags=[
 # credit top-up (POST /chunks/credit, listed in PROTECTED_ENDPOINTS); the chunk
 # upload itself spends prepaid credit via a bearer token, not a per-request payment.
 app.include_router(chunks.router, prefix=f"{settings.API_V1_STR}/chunks", tags=["chunks"], dependencies=x402_deps)
+# Signature-gated read-only Bee diagnostics proxy. Always mounted; the handler
+# returns 404 unless DEBUG_ALLOWED_ADDRESSES is configured.
+app.include_router(debug.router, prefix=f"{settings.API_V1_STR}/debug", tags=["debug"])
 
 @app.get("/", summary="Health Check", tags=["default"])
 @app.get("/health", summary="Health Check", tags=["default"], include_in_schema=False)

--- a/tests/test_debug_proxy.py
+++ b/tests/test_debug_proxy.py
@@ -1,0 +1,86 @@
+# tests/test_debug_proxy.py
+"""
+Tests for the signature-gated read-only Bee diagnostics proxy.
+"""
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from eth_account import Account
+from eth_account.messages import encode_defunct
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+KEY = "0x" + "22" * 32
+ADDR = Account.from_key(KEY).address
+OTHER_KEY = "0x" + "33" * 32
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _settings(allowed):
+    ms = MagicMock()
+    ms.get_debug_allowed_addresses.return_value = [a.lower() for a in allowed]
+    ms.DEBUG_SIG_MAX_AGE_SECONDS = 300
+    ms.SWARM_BEE_API_URL = "http://bee.local/"
+    return ms
+
+
+def _headers(key, ts=None):
+    ts = ts if ts is not None else int(time.time())
+    signed = Account.sign_message(encode_defunct(text=f"swarm-connect-debug:{ts}"), private_key=key)
+    return {"X-Debug-Timestamp": str(ts), "X-Debug-Signature": "0x" + bytes(signed.signature).hex()}
+
+
+def _mock_bee(body=b'{"depth":4,"connected":137}', status_code=200):
+    resp = MagicMock()
+    resp.content = body
+    resp.status_code = status_code
+    resp.headers = {"content-type": "application/json"}
+    c = MagicMock()
+    c.get = AsyncMock(return_value=resp)
+    return c
+
+
+def test_disabled_when_no_allowlist_returns_404(client):
+    with patch("app.api.endpoints.debug.settings", _settings([])):
+        r = client.get("/api/v1/debug/bee/topology", headers=_headers(KEY))
+    assert r.status_code == 404
+
+
+def test_missing_signature_401(client):
+    with patch("app.api.endpoints.debug.settings", _settings([ADDR])):
+        r = client.get("/api/v1/debug/bee/topology")
+    assert r.status_code == 401
+
+
+def test_stale_timestamp_401(client):
+    with patch("app.api.endpoints.debug.settings", _settings([ADDR])):
+        r = client.get("/api/v1/debug/bee/topology", headers=_headers(KEY, ts=int(time.time()) - 10000))
+    assert r.status_code == 401
+
+
+def test_non_allowlisted_signer_403(client):
+    with patch("app.api.endpoints.debug.settings", _settings([ADDR])):
+        # signed by a different key than the allow-listed address
+        r = client.get("/api/v1/debug/bee/topology", headers=_headers(OTHER_KEY))
+    assert r.status_code == 403
+
+
+def test_disallowed_path_403(client):
+    with patch("app.api.endpoints.debug.settings", _settings([ADDR])):
+        r = client.get("/api/v1/debug/bee/pinning", headers=_headers(KEY))  # 'pinning' not allow-listed
+    assert r.status_code == 403
+    assert r.json()["detail"]["code"] == "PATH_NOT_ALLOWED"
+
+
+def test_valid_request_proxies_to_bee(client):
+    with patch("app.api.endpoints.debug.settings", _settings([ADDR])):
+        with patch("app.api.endpoints.debug.get_client", return_value=_mock_bee()):
+            r = client.get("/api/v1/debug/bee/topology", headers=_headers(KEY))
+    assert r.status_code == 200
+    assert r.json()["connected"] == 137


### PR DESCRIPTION
Lets operators with only gateway access read the Bee node's diagnostics (topology/peers/status/...) to debug e.g. chunks accepted but not propagating (#236). Read-only, allow-listed paths, disabled unless DEBUG_ALLOWED_ADDRESSES is set, EIP-191 signature auth from an allow-listed address (no stored secret). Full suite 913 passed.