### PR TITLE
Surface Bee node connectivity/health on /health (network_availability, peers, mode)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ CORS (browser access):
 ### API Endpoints
 
 #### Core Endpoints
-- `GET /`: Health check endpoint
+- `GET /` (and `/health`): Health check. Always includes a `bee_node` section (from Bee `/topology` + `/status`, 15s cached): `mode`, `connected_peers`, `population`, `depth`, `reachability`, `network_availability` (Available/Unavailable/Unknown — Bee sets this from outbound-dial results; Unavailable = OS network/host-unreachable on dials), `storage_radius`, `reserve_size`, `warming_up`, `healthy`, `warnings`. Overall `status` → `degraded` when `network_availability` is `Unavailable` (node can't reach the storer network → uploads may 201 without propagating). x402 wallet section added when `X402_ENABLED`.
 
 #### Stamp Management
 - `POST /api/v1/stamps/`: Purchase new postage stamps (records purchase time for propagation tracking)

--- a/README.md
+++ b/README.md
@@ -265,7 +265,7 @@ Swarm Connect is a FastAPI-based API gateway that provides comprehensive access 
 ### Available API Endpoints
 
 #### Core Endpoints
-- `GET /`: Health check endpoint
+- `GET /` (and `/health`): Health check. Always includes a `bee_node` section with the Bee node's connectivity — `mode`, `connected_peers`, `population`, `reachability`, `network_availability` (Available/Unavailable/Unknown), `storage_radius`, `warming_up`, a `healthy` flag, and `warnings`. `status` becomes `degraded` when `network_availability` is `Unavailable` (the node can't reach the storer network, so uploads may return success without propagating). When x402 is enabled, also includes the `x402` wallet section.
 
 #### Stamp Management
 - `POST /api/v1/stamps/`: Purchase new postage stamps with time-based or advanced parameters

--- a/app/main.py
+++ b/app/main.py
@@ -172,6 +172,22 @@ async def read_root():
         "message": f"Welcome to {settings.PROJECT_NAME}"
     }
 
+    # Bee node connectivity/health — surfaces whether the node can actually reach
+    # the network (networkAvailability), peer count, mode, reserve. Cheap (cached),
+    # always included. A node with networkAvailability != Available accepts uploads
+    # (201) that may not propagate, so flag it here.
+    try:
+        from app.services.swarm_api import get_node_status_summary
+        node = await get_node_status_summary()
+        response_data["bee_node"] = node
+        # Only downgrade on a definitive bad signal (network unreachable -> uploads
+        # won't propagate). A transient inability to query the node, or warmup, is
+        # surfaced via bee_node.warnings but doesn't flip the gateway to degraded.
+        if node.get("network_availability") == "Unavailable" and response_data["status"] == "ok":
+            response_data["status"] = "degraded"
+    except Exception as e:
+        logger.warning(f"Health: failed to summarize Bee node status: {e}")
+
     # If x402 is enabled, include wallet status
     if settings.X402_ENABLED:
         from app.x402.base_balance import check_base_eth_balance

--- a/app/services/swarm_api.py
+++ b/app/services/swarm_api.py
@@ -1,6 +1,7 @@
 # app/services/swarm_api.py
 import asyncio
 import datetime
+import time
 import httpx
 import logging
 from typing import List, Dict, Any, Optional
@@ -745,6 +746,88 @@ async def download_data_from_swarm(reference: str) -> bytes:
         _record_bee_error("download")
         logger.error(f"Error downloading data from Swarm API ({api_url}): {e}")
         raise
+
+
+# Short cache so frequent /health calls don't hammer the Bee node.
+_node_status_cache: Dict[str, Any] = {"data": None, "ts": 0.0}
+NODE_STATUS_TTL_SECONDS = 15
+
+
+async def get_node_status_summary(use_cache: bool = True) -> Dict[str, Any]:
+    """
+    Summarize the Bee node's connectivity/health for the gateway /health endpoint.
+
+    Surfaces the signals that determine whether the node can actually push chunks to
+    the network: networkAvailability (Available/Unavailable/Unknown — set by Bee from
+    outbound dial results), connected peer count, mode, and reserve/radius. This lets
+    a client see node health directly from the gateway, without a slow cross-node
+    retrieval probe.
+
+    Returns a dict with a `healthy` boolean and human-readable `warnings`. Never raises.
+    """
+    now = time.time()
+    if use_cache and _node_status_cache["data"] is not None and (now - _node_status_cache["ts"]) < NODE_STATUS_TTL_SECONDS:
+        return _node_status_cache["data"]
+
+    topo: Dict[str, Any] = {}
+    status: Dict[str, Any] = {}
+    try:
+        client = get_client()
+        t_url = urljoin(str(settings.SWARM_BEE_API_URL), "topology")
+        s_url = urljoin(str(settings.SWARM_BEE_API_URL), "status")
+        tr, sr = await asyncio.gather(
+            client.get(t_url, timeout=8),
+            client.get(s_url, timeout=8),
+            return_exceptions=True,
+        )
+        if not isinstance(tr, Exception):
+            try:
+                tr.raise_for_status()
+                topo = tr.json()
+            except Exception:
+                pass
+        if not isinstance(sr, Exception):
+            try:
+                sr.raise_for_status()
+                status = sr.json()
+            except Exception:
+                pass
+    except Exception as e:
+        logger.warning(f"Failed to fetch Bee node status: {e}")
+
+    na = topo.get("networkAvailability")
+    warming = status.get("isWarmingUp")
+    summary: Dict[str, Any] = {
+        "mode": status.get("beeMode"),
+        "connected_peers": status.get("connectedPeers", topo.get("connected")),
+        "population": topo.get("population"),
+        "depth": topo.get("depth"),
+        "reachability": topo.get("reachability"),
+        "network_availability": na,
+        "neighborhood_size": status.get("neighborhoodSize"),
+        "storage_radius": status.get("storageRadius"),
+        "reserve_size": status.get("reserveSize"),
+        "warming_up": warming,
+    }
+
+    warnings = []
+    if not topo and not status:
+        warnings.append("could not query the Bee node (topology/status unavailable)")
+        summary["healthy"] = False
+    else:
+        if na is not None and na != "Available":
+            warnings.append(
+                f"network availability is '{na}' — the node may not reach the storer "
+                "network; uploads can report success without propagating"
+            )
+        if warming:
+            warnings.append("node is warming up")
+        summary["healthy"] = (na == "Available") and not bool(warming)
+    summary["warnings"] = warnings
+
+    _node_status_cache["data"] = summary
+    _node_status_cache["ts"] = now
+    return summary
 
 
 async def get_wallet_info() -> Dict[str, Any]:

--- a/tests/test_health_node.py
+++ b/tests/test_health_node.py
@@ -1,0 +1,100 @@
+# tests/test_health_node.py
+"""
+Tests for Bee node connectivity/health surfaced on the gateway /health endpoint.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import swarm_api
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _resp(data):
+    r = MagicMock()
+    r.raise_for_status = MagicMock()
+    r.json = MagicMock(return_value=data)
+    return r
+
+
+def _mock_client(topo, status):
+    def fake_get(url, timeout=8):
+        return _resp(topo if url.endswith("topology") else status)
+    c = MagicMock()
+    c.get = AsyncMock(side_effect=fake_get)
+    return c
+
+
+# --------------------------------------------------------------------------- #
+# summary derivation
+# --------------------------------------------------------------------------- #
+class TestNodeStatusSummary:
+    @pytest.mark.asyncio
+    async def test_unavailable_is_unhealthy_with_warning(self):
+        topo = {"networkAvailability": "Unavailable", "connected": 15, "population": 1317,
+                "depth": 9, "reachability": "Private"}
+        status = {"beeMode": "light", "connectedPeers": 15, "neighborhoodSize": 16,
+                  "storageRadius": 0, "reserveSize": 0, "isWarmingUp": False}
+        swarm_api._node_status_cache["data"] = None
+        with patch("app.services.swarm_api.get_client", return_value=_mock_client(topo, status)):
+            s = await swarm_api.get_node_status_summary(use_cache=False)
+        assert s["network_availability"] == "Unavailable"
+        assert s["connected_peers"] == 15
+        assert s["mode"] == "light"
+        assert s["healthy"] is False
+        assert any("network availability" in w for w in s["warnings"])
+
+    @pytest.mark.asyncio
+    async def test_available_is_healthy(self):
+        topo = {"networkAvailability": "Available", "connected": 137, "population": 3794,
+                "depth": 9, "reachability": "Private"}
+        status = {"beeMode": "light", "connectedPeers": 137, "isWarmingUp": False,
+                  "storageRadius": 0, "reserveSize": 0}
+        swarm_api._node_status_cache["data"] = None
+        with patch("app.services.swarm_api.get_client", return_value=_mock_client(topo, status)):
+            s = await swarm_api.get_node_status_summary(use_cache=False)
+        assert s["healthy"] is True
+        assert s["warnings"] == []
+
+    @pytest.mark.asyncio
+    async def test_unreachable_node_is_unhealthy(self):
+        # both calls raise -> empty topo/status
+        c = MagicMock()
+        c.get = AsyncMock(side_effect=Exception("bee down"))
+        swarm_api._node_status_cache["data"] = None
+        with patch("app.services.swarm_api.get_client", return_value=c):
+            s = await swarm_api.get_node_status_summary(use_cache=False)
+        assert s["healthy"] is False
+        assert any("could not query" in w for w in s["warnings"])
+
+
+# --------------------------------------------------------------------------- #
+# /health integration
+# --------------------------------------------------------------------------- #
+class TestHealthEndpoint:
+    def test_health_includes_node_and_stays_ok_when_healthy(self, client):
+        summary = {"mode": "light", "connected_peers": 137, "network_availability": "Available",
+                   "healthy": True, "warnings": []}
+        with patch("app.services.swarm_api.get_node_status_summary", new=AsyncMock(return_value=summary)):
+            r = client.get("/health")
+        assert r.status_code == 200
+        b = r.json()
+        assert b["bee_node"]["network_availability"] == "Available"
+        assert b["status"] == "ok"
+
+    def test_health_degraded_when_node_unavailable(self, client):
+        summary = {"mode": "light", "connected_peers": 15, "network_availability": "Unavailable",
+                   "healthy": False, "warnings": ["network availability is 'Unavailable' — ..."]}
+        with patch("app.services.swarm_api.get_node_status_summary", new=AsyncMock(return_value=summary)):
+            r = client.get("/health")
+        assert r.status_code == 200
+        b = r.json()
+        assert b["bee_node"]["healthy"] is False
+        assert b["status"] == "degraded"
+        assert any("network availability" in w for w in b["bee_node"]["warnings"])

--- a/tests/test_x402_integration.py
+++ b/tests/test_x402_integration.py
@@ -615,7 +615,9 @@ class TestHealthEndpointWithX402:
         mock_settings.X402_ENABLED = False
         mock_settings.PROJECT_NAME = "Test Gateway"
         from app.main import read_root
-        response = await read_root()
+        with patch("app.services.swarm_api.get_node_status_summary",
+                   new=AsyncMock(return_value={"healthy": True, "network_availability": "Available", "warnings": []})):
+            response = await read_root()
         assert response["status"] == "ok"
         assert "x402" not in response
 
@@ -640,7 +642,9 @@ class TestHealthEndpointWithX402:
             "warnings": [], "errors": []
         }
         from app.main import read_root
-        response = await read_root()
+        with patch("app.services.swarm_api.get_node_status_summary",
+                   new=AsyncMock(return_value={"healthy": True, "network_availability": "Available", "warnings": []})):
+            response = await read_root()
         assert response["status"] == "ok"
         assert response["x402"]["enabled"] is True
 


### PR DESCRIPTION
Adds a bee_node section to /health showing the Bee node's connectivity (network_availability, connected_peers, mode, storage_radius, ...) so operators can see node health directly from the gateway — no cross-node probe. status -> degraded when network_availability is Unavailable (uploads can 201 without propagating; see #236). Full suite 918 passed.